### PR TITLE
provides own gmean implementation

### DIFF
--- a/elegant/core.py
+++ b/elegant/core.py
@@ -1,8 +1,12 @@
 import networkx as nx
 import numpy as np
-from scipy.stats.mstats import gmean
 
 from .methods import newton_raphson, short
+
+
+def gmean(arr):
+    return np.prod(arr) ** (1 / len(arr))
+
 
 NAME = "Elegant"
 
@@ -22,8 +26,6 @@ DELTA_SYMBOL = "\u0394"
 PY_TO_SYMBOL = {STAR: STAR_SYMBOL, EARTH: EARTH_SYMBOL, DELTA: DELTA_SYMBOL}
 SYMBOL_TO_PY = {STAR_SYMBOL: STAR, EARTH_SYMBOL: EARTH, DELTA_SYMBOL: DELTA}
 
-
-# ToDo defasagem dos trafos
 
 class Bus(object):
     def __init__(self, bus_id, v=1.0, delta=0.0, pg=0.0, qg=0.0, pl=0.0, ql=0.0,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ networkx
 numpy
 pylatex
 PyQt5
-scipy

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     url="https://github.com/dioph/elegant",
     packages=["elegant"],
     entry_points={"console_scripts": ['elegant=elegant.interface:main']},
-    install_requires=["networkx", "numpy", "scipy"],
+    install_requires=["networkx", "numpy"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",


### PR DESCRIPTION
This is an alternative implementation to the one in `scipy.stats.mstats.gmean`, dropping the requirement for `scipy`.
I investigated whether this would cause a decrease in performance but it actually seems to be a tiny bit faster (probably due to the small size of the arrays we need to deal with):

```
%timeit mygmean(np.random.rand(3))
7.39 µs ± 203 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
%timeit scipy.stats.mstats.gmean(np.random.rand(3))
13.3 µs ± 129 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```