### PR TITLE
[Bugfix] Display `bus_id` in the bus inspector starting from 1

### DIFF
--- a/elegant/interface.py
+++ b/elegant/interface.py
@@ -902,7 +902,7 @@ class CircuitInputer(QWidget):
             if bus.bus_id == 0:
                 self.BusTitle.setText('Slack')
             else:
-                self.BusTitle.setText('Bus {}'.format(bus.bus_id))
+                self.BusTitle.setText('Bus {}'.format(bus.bus_id + 1))
             if bus.pl > 0 or bus.ql > 0:
                 self.AddLoadButton.setText('-')
                 self.AddLoadButton.disconnect()


### PR DESCRIPTION
The intended behavior was for the Slack to correspond to Bus #1 and start counting the other buses from 2 onwards. This matches the IDs displayed in report tables.