### PR TITLE
Enforcing PEP8 style guide for interface module

### DIFF
--- a/elegant/interface.py
+++ b/elegant/interface.py
@@ -9,6 +9,15 @@ from .core import *
 from .report import create_report
 from .utils import *
 
+STAR = 0
+EARTH = 1
+DELTA = 2
+STAR_SYMBOL = "Y"
+EARTH_SYMBOL = "Y\u23DA"
+DELTA_SYMBOL = "\u0394"
+
+PY_TO_SYMBOL = {STAR: STAR_SYMBOL, EARTH: EARTH_SYMBOL, DELTA: DELTA_SYMBOL}
+SYMBOL_TO_PY = {STAR_SYMBOL: STAR, EARTH_SYMBOL: EARTH, DELTA_SYMBOL: DELTA}
 
 class Block:
     def __init__(self, start=False, end=True):
@@ -63,9 +72,9 @@ class HistoryData:
         self.current = [x, y]
 
 
-class View(QGraphicsView):
-    def __init__(self, QGraphicsScene):
-        super(View, self).__init__(QGraphicsScene)
+class ScrollView(QGraphicsView):
+    def __init__(self, scene):
+        super(ScrollView, self).__init__(scene)
         self.horizontalScrollBar().valueChanged.connect(self.erase)
         self.verticalScrollBar().valueChanged.connect(self.erase)
 
@@ -75,37 +84,37 @@ class View(QGraphicsView):
             self.scene().selectorHistory.dsquare_obj = None
 
 
-class SchemeInputer(QGraphicsScene):
-    def __init__(self, n=20, length=50):
-        super(SchemeInputer, self).__init__()
-        self.N = n
-        self.View = View(self)
+class Editor(QGraphicsScene):
+    def __init__(self, size=20, length=50):
+        super(Editor, self).__init__()
+        self.size = size
+        self.View = ScrollView(self)
 
         # System state variables
-        self.pixmap = np.zeros((self.N, self.N), object)
-        self.grid = np.zeros((self.N, self.N), object)
-        self.oneSquareSideLength = length
+        self.drawings = np.zeros((self.size, self.size), object)
+        self.bus_grid = np.zeros((self.size, self.size), object)
+        self.square_length = length
         self.move_history = HistoryData()
         self.block = Block()
         self.selectorHistory = HistoryData()
         self.selectorHistory.__setattr__('dsquare_obj', None)
 
-        self.pointerSignal = GenericSignal()
-        self.methodSignal = GenericSignal()
-        self.dataSignal = GenericSignal()
+        self.pointer_signal = GenericSignal()
+        self.method_signal = GenericSignal()
+        self.data_signal = GenericSignal()
 
         # Visible portion of Scene to View
-        self.bump_circle_radius = length / 2
+        self.circle_radius = length / 2
         self.setSceneRect(0,
                           0,
-                          self.oneSquareSideLength * self.N,
-                          self.oneSquareSideLength * self.N)
-        self.quantizedInterface = self.getQuantizedInterface()
-        self.showQuantizedInterface()
-        self.setSceneRect(self.oneSquareSideLength * -2,
-                          self.oneSquareSideLength * -2,
-                          self.oneSquareSideLength * (self.N + 4),
-                          self.oneSquareSideLength * (self.N + 4))
+                          self.square_length * self.size,
+                          self.square_length * self.size)
+        self.coord_grid = self.get_coord_grid()
+        self.draw_grid()
+        self.setSceneRect(self.square_length * -2,
+                          self.square_length * -2,
+                          self.square_length * (self.size + 4),
+                          self.square_length * (self.size + 4))
 
     @staticmethod
     def distance(interface_point, point):
@@ -131,16 +140,16 @@ class SchemeInputer(QGraphicsScene):
         -------
         : index codes for point, given its quantized coordinates
         """
-        i = int((central_point.y() - self.oneSquareSideLength / 2) / self.oneSquareSideLength)
-        j = int((central_point.x() - self.oneSquareSideLength / 2) / self.oneSquareSideLength)
+        i = int((central_point.y() - self.square_length / 2) / self.square_length)
+        j = int((central_point.x() - self.square_length / 2) / self.square_length)
         return i, j
 
     def QPoint_from_ij(self, i, j):
-        for central_point in self.quantizedInterface.flatten():
+        for central_point in self.coord_grid.flatten():
             if (i, j) == self.ij_from_QPoint(central_point):
                 return central_point
 
-    def drawLine(self, coordinates, color='b'):
+    def draw_line(self, coordinates, color='b'):
         """
         Parameters
         ----------
@@ -161,7 +170,7 @@ class SchemeInputer(QGraphicsScene):
         line = self.addLine(coordinates[0, 0], coordinates[0, 1], coordinates[1, 0], coordinates[1, 1], pen)
         return line
 
-    def drawSquare(self, coordinates):
+    def draw_square(self, coordinates):
         """
         Parameters
         ----------
@@ -174,20 +183,20 @@ class SchemeInputer(QGraphicsScene):
         pen = QPen(Qt.yellow)
         brush = QBrush(Qt.yellow, Qt.Dense7Pattern)
         x, y = coordinates
-        rect = self.addRect(x, y, self.oneSquareSideLength, self.oneSquareSideLength, pen, brush)
+        rect = self.addRect(x, y, self.square_length, self.square_length, pen, brush)
         return rect
 
-    def drawBus(self, coordinates):
-        c = np.array(coordinates) - self.oneSquareSideLength / 4
+    def draw_bus(self, coordinates):
+        c = np.array(coordinates) - self.square_length / 4
         pen = QPen(Qt.black)
         brush = QBrush(Qt.SolidPattern)
-        ellipse = self.addEllipse(*c, self.oneSquareSideLength / 2, self.oneSquareSideLength / 2, pen, brush)
+        ellipse = self.addEllipse(*c, self.square_length / 2, self.square_length / 2, pen, brush)
         return ellipse
 
     def get_central_point(self, event):
         coordinates = event.scenePos().x(), event.scenePos().y()
-        for central_point in self.quantizedInterface.flatten():
-            if self.distance(coordinates, central_point) <= self.bump_circle_radius:
+        for central_point in self.coord_grid.flatten():
+            if self.distance(coordinates, central_point) <= self.circle_radius:
                 i, j = self.ij_from_QPoint(central_point)
                 return central_point, i, j
 
@@ -195,31 +204,31 @@ class SchemeInputer(QGraphicsScene):
         self.move_history.reset()
         self.block.start = True
         self.block.end = False
-        self.methodSignal.emit_sig(3)
+        self.method_signal.emit_sig(3)
 
     def mouseDoubleClickEvent(self, event):
         if self.get_central_point(event):
             central_point, i, j = self.get_central_point(event)
-            sceneItem = self.drawBus((central_point.x(), central_point.y()))
-            self.pixmap[(i, j)] = sceneItem
-            self.pointerSignal.emit_sig((i, j))
-            self.methodSignal.emit_sig(0)
+            circle = self.draw_bus((central_point.x(), central_point.y()))
+            self.drawings[i, j] = circle
+            self.pointer_signal.emit_sig((i, j))
+            self.method_signal.emit_sig(0)
 
     def redraw_cursor(self, x, y):
         if self.selectorHistory.dsquare_obj is not None:
             self.removeItem(self.selectorHistory.dsquare_obj)
-        self.selectorHistory.set_current(x - self.oneSquareSideLength / 2,
-                                         y - self.oneSquareSideLength / 2)
-        self.selectorHistory.dsquare_obj = self.drawSquare(self.selectorHistory.current)
+        self.selectorHistory.set_current(x - self.square_length / 2,
+                                         y - self.square_length / 2)
+        self.selectorHistory.dsquare_obj = self.draw_square(self.selectorHistory.current)
 
     def mousePressEvent(self, event):
         if self.get_central_point(event):
             central_point, i, j = self.get_central_point(event)
             x, y = central_point.x(), central_point.y()
             self.redraw_cursor(x, y)
-            self.pointerSignal.emit_sig((i, j))
-            self.methodSignal.emit_sig(4)
-            self.methodSignal.emit_sig(2)
+            self.pointer_signal.emit_sig((i, j))
+            self.method_signal.emit_sig(4)
+            self.method_signal.emit_sig(2)
 
     @property
     def is_drawing_blocked(self):
@@ -227,11 +236,11 @@ class SchemeInputer(QGraphicsScene):
 
     def draw_line_suite(self, i, j):
         coordinates = np.atleast_2d(np.array([self.move_history.last, self.move_history.current]))
-        line = self.drawLine(coordinates, color='b')
+        line = self.draw_line(coordinates, color='b')
         self.move_history.reset()
-        self.pointerSignal.emit_sig((i, j))
-        self.dataSignal.emit_sig(line)
-        self.methodSignal.emit_sig(1)
+        self.pointer_signal.emit_sig((i, j))
+        self.data_signal.emit_sig(line)
+        self.method_signal.emit_sig(1)
 
     def mouseMoveEvent(self, event):
         if self.get_central_point(event):
@@ -241,38 +250,38 @@ class SchemeInputer(QGraphicsScene):
                 self.redraw_cursor(x, y)
                 if self.move_history.is_empty:
                     self.move_history.set_last(x, y)
-                    if isinstance(self.grid[i, j], Bus):
+                    if isinstance(self.bus_grid[i, j], Bus):
                         self.block.start = False
                 if self.move_history.is_last_different_from(x, y):
                     self.move_history.set_current(x, y)
                 if self.move_history.allows_drawing and not self.is_drawing_blocked:
                     self.draw_line_suite(i, j)
-                    if isinstance(self.grid[i, j], Bus):
+                    if isinstance(self.bus_grid[i, j], Bus):
                         self.block.end = True
 
-    def getQuantizedInterface(self):
+    def get_coord_grid(self):
         """
         Returns
         -------
-        quantizedInterface: numpy array that holds PyQt QPoint objects with quantized interface coordinates
+        coord_grid: numpy array that holds PyQt QPoint objects with quantized interface coordinates
         """
-        quantizedInterface = np.zeros((self.N, self.N), tuple)
+        coord_grid = np.zeros((self.size, self.size), tuple)
         width, height = self.width(), self.height()
-        for i in range(self.N):
-            for j in range(self.N):
-                quantizedInterface[i, j] = QPoint(int(width / (2 * self.N) + i * width / self.N),
-                                                  int(height / (2 * self.N) + j * height / self.N))
-        return quantizedInterface
+        for i in range(self.size):
+            for j in range(self.size):
+                coord_grid[i, j] = QPoint(int(width / (2 * self.size) + i * width / self.size),
+                                          int(height / (2 * self.size) + j * height / self.size))
+        return coord_grid
 
-    def showQuantizedInterface(self):
+    def draw_grid(self):
         """Display the quantized interface guidelines"""
         width, height = self.width(), self.height()
-        spacing_x, spacing_y = width / self.N, height / self.N
+        spacing_x, spacing_y = width / self.size, height / self.size
         quantized_x, quantized_y = np.arange(0, width, spacing_x), np.arange(0, height, spacing_y)
         pen = QPen()
         pen.setColor(Qt.lightGray)
         pen.setStyle(Qt.DashDotDotLine)
-        for k in range(self.N):
+        for k in range(self.size):
             # Horizontal lines
             self.addLine(0.0, quantized_y[k], width, quantized_y[k], pen)
             # Vertical lines
@@ -281,432 +290,434 @@ class SchemeInputer(QGraphicsScene):
         self.addLine(self.width(), 0.0, self.width(), height, pen)
 
 
-class CircuitInputer(QWidget):
+class MainWidget(QWidget):
     def __init__(self, parent=None):
         # General initializations
-        super(CircuitInputer, self).__init__(parent)
+        super(MainWidget, self).__init__(parent)
         self.system = PowerSystem()
-        self.line_types = {'Default': TransmissionLine(orig=None, dest=None)}
+        self.line_types = {"Default": TransmissionLine(orig=None, dest=None)}
         self.curves = []
-        self.nmax = 20
+        self.max_niter = 20
         self.sidebar_width = 200
 
-        self.Scene = SchemeInputer()
+        self.editor = Editor()
 
         # self.View = QGraphicsView(self.Scene)
-        self.View = self.Scene.View
-        self.SchemeInputLayout = QHBoxLayout()  # Layout for SchemeInput
-        self.SchemeInputLayout.addWidget(self.View)
-        self._currElementCoords = None  # Coordinates to current object being manipuled
-        self._startNewTL = True
+        self.view = self.editor.View
+        self.editor_layout = QHBoxLayout()  # Layout for SchemeInput
+        self.editor_layout.addWidget(self.view)
+        self._curr_element_coord = None  # Coordinates to current object being manipuled
+        self._start_line = True
         self._line_origin = None
         self._temp = None
-        self.statusMsg = GenericSignal()
+        self.status_msg = GenericSignal()
         self.__calls = {0: self.add_bus,
                         1: self.add_segment,
-                        2: self.LayoutManager,
-                        3: self.doAfterMouseRelease,
-                        4: self.storeOriginAddLine}
-        self.Scene.pointerSignal.signal.connect(lambda args: self.setCurrentObject(args))
-        self.Scene.dataSignal.signal.connect(lambda args: self.setTemp(args))
-        self.Scene.methodSignal.signal.connect(lambda args: self.methodsTrigger(args))
+                        2: self.update_layout,
+                        3: self.update_values,
+                        4: self.store_line_origin}
+        self.editor.pointer_signal.signal.connect(self.set_current_coord)
+        self.editor.data_signal.signal.connect(self.set_temp)
+        self.editor.method_signal.signal.connect(self.methods_trigger)
 
         # Inspectors
-        self.InspectorLayout = QVBoxLayout()
+        self.inspector_layout = QVBoxLayout()
 
         # Layout for general bus case
-        self.BusLayout = QVBoxLayout()
+        self.bus_layout = QVBoxLayout()
 
         # Bus title
-        self.BusTitle = QLabel('Bus title')
-        self.BusTitle.setAlignment(Qt.AlignCenter)
-        self.BusTitle.setMinimumWidth(self.sidebar_width)
-        self.BusTitle.setMaximumWidth(self.sidebar_width)
+        self.bus_title = QLabel("Bus title")
+        self.bus_title.setAlignment(Qt.AlignCenter)
+        self.bus_title.setMinimumWidth(self.sidebar_width)
+        self.bus_title.setMaximumWidth(self.sidebar_width)
 
         # Bus voltage
-        self.BusV_Value = QLineEdit('0.0')
-        self.BusV_Value.setEnabled(False)
-        self.BusV_Value.setValidator(QDoubleValidator(bottom=0., top=100.))
+        self.bus_v_value = QLineEdit("0.0")
+        self.bus_v_value.setEnabled(False)
+        self.bus_v_value.setValidator(QDoubleValidator(bottom=0., top=100.))
 
         # Bus angle
-        self.BusAngle_Value = QLineEdit('0.0')
-        self.BusAngle_Value.setEnabled(False)
+        self.bus_angle_value = QLineEdit("0.0")
+        self.bus_angle_value.setEnabled(False)
 
         # FormLayout to hold bus data
-        self.BusDataFormLayout = QFormLayout()
+        self.bus_data_form_layout = QFormLayout()
 
         # Adding bus voltage and bus angle to bus data FormLayout
-        self.BusDataFormLayout.addRow('|V| (pu)', self.BusV_Value)
-        self.BusDataFormLayout.addRow('\u03b4 (\u00B0)', self.BusAngle_Value)
+        self.bus_data_form_layout.addRow("|V| (pu)", self.bus_v_value)
+        self.bus_data_form_layout.addRow("\u03b4 (\u00B0)", self.bus_angle_value)
 
         # Label with 'Generation'
-        self.AddGenerationLabel = QLabel('Generation')
-        self.AddGenerationLabel.setAlignment(Qt.AlignCenter)
+        self.add_generation_label = QLabel("Generation")
+        self.add_generation_label.setAlignment(Qt.AlignCenter)
 
         # Button to add generation
-        self.AddGenerationButton = QPushButton('+')
-        self.AddGenerationButton.pressed.connect(self.add_gen)  # Bind button to make input editable
+        self.add_generation_button = QPushButton('+')
+        self.add_generation_button.pressed.connect(self.add_gen)  # Bind button to make input editable
 
         # FormLayout to add generation section
-        self.AddGenerationFormLayout = QFormLayout()
-        self.AddLoadFormLayout = QFormLayout()
+        self.add_generation_form_layout = QFormLayout()
+        self.add_load_form_layout = QFormLayout()
 
         # Line edit to Xd bus
-        self.XdLineEdit = QLineEdit('\u221E')
-        self.XdLineEdit.setValidator(QDoubleValidator())
-        self.XdLineEdit.setEnabled(False)
+        self.xd_line_edit = QLineEdit("\u221E")
+        self.xd_line_edit.setValidator(QDoubleValidator())
+        self.xd_line_edit.setEnabled(False)
 
         # Line edit to input bus Pg
-        self.PgInput = QLineEdit('0.0')
-        self.PgInput.setValidator(QDoubleValidator(bottom=0.))
-        self.PgInput.setEnabled(False)
+        self.pg_input = QLineEdit("0.0")
+        self.pg_input.setValidator(QDoubleValidator(bottom=0.))
+        self.pg_input.setEnabled(False)
 
         # Line edit to input bus Qg
-        self.QgInput = QLineEdit('0.0')
-        self.QgInput.setValidator(QDoubleValidator())
-        self.QgInput.setEnabled(False)
+        self.qg_input = QLineEdit("0.0")
+        self.qg_input.setValidator(QDoubleValidator())
+        self.qg_input.setEnabled(False)
 
         # Check box for generation ground
-        self.GenGround = QCheckBox("\u23DA")
-        self.GenGround.setEnabled(False)
+        self.gen_ground = QCheckBox("\u23DA")
+        self.gen_ground.setEnabled(False)
 
         # Adding Pg, Qg to add generation FormLayout
-        self.AddGenerationFormLayout.addRow('x (%pu)', self.XdLineEdit)
-        self.AddGenerationFormLayout.addRow('P<sub>G</sub> (MW)', self.PgInput)
-        self.AddGenerationFormLayout.addRow('Q<sub>G</sub> (Mvar)', self.QgInput)
-        self.AddGenerationFormLayout.addRow('Y', self.GenGround)
+        self.add_generation_form_layout.addRow("x (%pu)", self.xd_line_edit)
+        self.add_generation_form_layout.addRow("P<sub>G</sub> (MW)", self.pg_input)
+        self.add_generation_form_layout.addRow("Q<sub>G</sub> (Mvar)", self.qg_input)
+        self.add_generation_form_layout.addRow("Y", self.gen_ground)
 
         # Label with 'Load'
-        self.AddLoadLabel = QLabel('Load')
-        self.AddLoadLabel.setAlignment(Qt.AlignCenter)
+        self.add_load_label = QLabel("Load")
+        self.add_load_label.setAlignment(Qt.AlignCenter)
 
         # PushButton that binds to three different methods
-        self.AddLoadButton = QPushButton('+')
-        self.AddLoadButton.pressed.connect(self.add_load)
+        self.add_load_button = QPushButton('+')
+        self.add_load_button.pressed.connect(self.add_load)
 
         # LineEdit with Ql, Pl
-        self.QlInput = QLineEdit('0.0')
-        self.QlInput.setValidator(QDoubleValidator())
-        self.PlInput = QLineEdit('0.0')
-        self.PlInput.setValidator(QDoubleValidator())
-        self.PlInput.setEnabled(False)
-        self.QlInput.setEnabled(False)
+        self.ql_input = QLineEdit("0.0")
+        self.ql_input.setValidator(QDoubleValidator())
+        self.pl_input = QLineEdit("0.0")
+        self.pl_input.setValidator(QDoubleValidator())
+        self.pl_input.setEnabled(False)
+        self.ql_input.setEnabled(False)
 
         # Check box to load ground
         # self.LoadGround = QCheckBox("\u23DA")
-        self.LoadGround = QComboBox()
-        self.LoadGround.addItem("Y")
-        self.LoadGround.addItem("Y\u23DA")
-        self.LoadGround.addItem("\u0394")
-        self.LoadGround.setEnabled(False)
+        self.load_ground = QComboBox()
+        self.load_ground.addItem("Y")
+        self.load_ground.addItem("Y\u23DA")
+        self.load_ground.addItem("\u0394")
+        self.load_ground.setEnabled(False)
 
         # Adding Pl and Ql to add load FormLayout
-        self.AddLoadFormLayout.addRow('P<sub>L</sub> (MW)', self.PlInput)
-        self.AddLoadFormLayout.addRow('Q<sub>L</sub> (Mvar)', self.QlInput)
-        self.AddLoadFormLayout.addRow('Y', self.LoadGround)
+        self.add_load_form_layout.addRow("P<sub>L</sub> (MW)", self.pl_input)
+        self.add_load_form_layout.addRow("Q<sub>L</sub> (Mvar)", self.ql_input)
+        self.add_load_form_layout.addRow("Y", self.load_ground)
 
-        self.RemoveBus = QPushButton('Remove bus')
-        self.RemoveBus.pressed.connect(self.remove_bus)
+        self.remove_bus_button = QPushButton('Remove bus')
+        self.remove_bus_button.pressed.connect(self.remove_bus)
 
-        self.BusLayout.addWidget(self.BusTitle)
-        self.BusLayout.addLayout(self.BusDataFormLayout)
-        self.BusLayout.addWidget(self.AddGenerationLabel)
-        self.BusLayout.addWidget(self.AddGenerationButton)
-        self.BusLayout.addLayout(self.AddGenerationFormLayout)
-        self.BusLayout.addWidget(self.AddLoadLabel)
-        self.BusLayout.addWidget(self.AddLoadButton)
-        self.BusLayout.addLayout(self.AddLoadFormLayout)
-        self.BusLayout.addWidget(self.RemoveBus)
+        self.bus_layout.addWidget(self.bus_title)
+        self.bus_layout.addLayout(self.bus_data_form_layout)
+        self.bus_layout.addWidget(self.add_generation_label)
+        self.bus_layout.addWidget(self.add_generation_button)
+        self.bus_layout.addLayout(self.add_generation_form_layout)
+        self.bus_layout.addWidget(self.add_load_label)
+        self.bus_layout.addWidget(self.add_load_button)
+        self.bus_layout.addLayout(self.add_load_form_layout)
+        self.bus_layout.addWidget(self.remove_bus_button)
 
         # Layout for input new type of line
-        self.InputNewLineType = QVBoxLayout()
-        self.InputNewLineTypeFormLayout = QFormLayout()
+        self.new_line_type = QVBoxLayout()
+        self.new_line_type_form_layout = QFormLayout()
 
-        self.ModelName = QLineEdit()
-        self.ModelName.setValidator(QRegExpValidator(QRegExp("[A-Za-z]*")))
-        self.RhoLineEdit = QLineEdit()
-        self.RhoLineEdit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.rLineEdit = QLineEdit()
-        self.rLineEdit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.d12LineEdit = QLineEdit()
-        self.d12LineEdit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.d23LineEdit = QLineEdit()
-        self.d23LineEdit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.d31LineEdit = QLineEdit()
-        self.d31LineEdit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.dLineEdit = QLineEdit()
-        self.dLineEdit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.mLineEdit = QLineEdit()
-        self.mLineEdit.setValidator(QIntValidator(bottom=1, top=4))
-        self.imaxLineEdit = QLineEdit()
-        self.imaxLineEdit.setValidator(QDoubleValidator(bottom=0.))
+        self.model_name = QLineEdit()
+        self.model_name.setValidator(QRegExpValidator(QRegExp("[A-Za-z]*")))
+        self.rho_line_edit = QLineEdit()
+        self.rho_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        self.r_line_edit = QLineEdit()
+        self.r_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        self.d12_line_edit = QLineEdit()
+        self.d12_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        self.d23_line_edit = QLineEdit()
+        self.d23_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        self.d31_line_edit = QLineEdit()
+        self.d31_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        self.d_line_edit = QLineEdit()
+        self.d_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        self.m_line_edit = QLineEdit()
+        self.m_line_edit.setValidator(QIntValidator(bottom=1, top=4))
+        self.imax_line_edit = QLineEdit()
+        self.imax_line_edit.setValidator(QDoubleValidator(bottom=0.))
 
-        self.InputNewLineTypeFormLayout.addRow('Name', self.ModelName)
-        self.InputNewLineTypeFormLayout.addRow('\u03C1 (n\u03A9m)', self.RhoLineEdit)
-        self.InputNewLineTypeFormLayout.addRow('r (mm)', self.rLineEdit)
-        self.InputNewLineTypeFormLayout.addRow('d12 (m)', self.d12LineEdit)
-        self.InputNewLineTypeFormLayout.addRow('d23 (m)', self.d23LineEdit)
-        self.InputNewLineTypeFormLayout.addRow('d31 (m)', self.d31LineEdit)
-        self.InputNewLineTypeFormLayout.addRow('d (m)', self.dLineEdit)
-        self.InputNewLineTypeFormLayout.addRow('m', self.mLineEdit)
-        self.InputNewLineTypeFormLayout.addRow('Imax (A)', self.imaxLineEdit)
+        self.new_line_type_form_layout.addRow("Name", self.model_name)
+        self.new_line_type_form_layout.addRow("\u03C1 (n\u03A9m)", self.rho_line_edit)
+        self.new_line_type_form_layout.addRow("r (mm)", self.r_line_edit)
+        self.new_line_type_form_layout.addRow("d12 (m)", self.d12_line_edit)
+        self.new_line_type_form_layout.addRow("d23 (m)", self.d23_line_edit)
+        self.new_line_type_form_layout.addRow("d31 (m)", self.d31_line_edit)
+        self.new_line_type_form_layout.addRow("d (m)", self.d_line_edit)
+        self.new_line_type_form_layout.addRow("m", self.m_line_edit)
+        self.new_line_type_form_layout.addRow("Imax (A)", self.imax_line_edit)
 
-        self.InputNewLineType.addStretch()
-        self.InputNewLineType.addLayout(self.InputNewLineTypeFormLayout)
-        self.SubmitNewLineTypePushButton = QPushButton('Submit')
-        self.SubmitNewLineTypePushButton.setMinimumWidth(self.sidebar_width)
-        self.SubmitNewLineTypePushButton.setMaximumWidth(self.sidebar_width)
-        self.SubmitNewLineTypePushButton.pressed.connect(self.addNewLineType)
-        self.InputNewLineType.addWidget(self.SubmitNewLineTypePushButton)
-        self.InputNewLineType.addStretch()
+        self.new_line_type.addStretch()
+        self.new_line_type.addLayout(self.new_line_type_form_layout)
+        self.submit_new_line_type_push_button = QPushButton("Submit")
+        self.submit_new_line_type_push_button.setMinimumWidth(self.sidebar_width)
+        self.submit_new_line_type_push_button.setMaximumWidth(self.sidebar_width)
+        self.submit_new_line_type_push_button.pressed.connect(self.add_new_line_model)
+        self.new_line_type.addWidget(self.submit_new_line_type_push_button)
+        self.new_line_type.addStretch()
 
         # Layout for simulation control panel
-        self.ControlPanelLayout = QVBoxLayout()
+        self.control_panel_layout = QVBoxLayout()
 
-        self.NmaxHbox = QHBoxLayout()
-        self.NmaxSlider = QSlider()
-        self.NmaxSlider.setMinimum(0)
-        self.NmaxSlider.setMaximum(50)
-        self.NmaxSlider.setOrientation(Qt.Vertical)
-        self.NmaxLabel = QLabel('Nmax: {:02d}'.format(self.nmax))
-        self.NmaxSlider.valueChanged.connect(lambda: self.setNmaxValue(self.NmaxSlider.value()))
-        self.NmaxHbox.addWidget(self.NmaxLabel)
-        self.NmaxHbox.addWidget(self.NmaxSlider)
+        self.nmax_hbox = QHBoxLayout()
+        self.nmax_slider = QSlider()
+        self.nmax_slider.setMinimum(0)
+        self.nmax_slider.setMaximum(50)
+        self.nmax_slider.setOrientation(Qt.Vertical)
+        self.nmax_label = QLabel("Nmax: {:02d}".format(self.max_niter))
+        self.nmax_slider.valueChanged.connect(self.set_nmax)
+        self.nmax_hbox.addWidget(self.nmax_label)
+        self.nmax_hbox.addWidget(self.nmax_slider)
 
-        self.ControlPanelLayout.addStretch()
-        self.ControlPanelLayout.addLayout(self.NmaxHbox)
-        self.ControlPanelLayout.addStretch()
+        self.control_panel_layout.addStretch()
+        self.control_panel_layout.addLayout(self.nmax_hbox)
+        self.control_panel_layout.addStretch()
 
         # General Layout for TL case
-        self.LineOrTrafoLayout = QVBoxLayout()
+        self.line_or_trafo_layout = QVBoxLayout()
 
-        self.chooseLine = QRadioButton('TL')
-        self.chooseTrafo = QRadioButton('TRAFO')
-        self.chooseLine.toggled.connect(self.defineLineOrTrafoVisibility)
-        self.chooseTrafo.toggled.connect(self.defineLineOrTrafoVisibility)
+        self.choose_line = QRadioButton("TL")
+        self.choose_trafo = QRadioButton("TRAFO")
+        self.choose_line.toggled.connect(self.toggle_line_trafo)
+        self.choose_trafo.toggled.connect(self.toggle_line_trafo)
 
-        self.chooseLineOrTrafo = QHBoxLayout()
-        self.chooseLineOrTrafo.addWidget(QLabel('TL/TRAFO:'))
-        self.chooseLineOrTrafo.addWidget(self.chooseLine)
-        self.chooseLineOrTrafo.addWidget(self.chooseTrafo)
+        self.choose_line_or_trafo = QHBoxLayout()
+        self.choose_line_or_trafo.addWidget(QLabel("TL/TRAFO:"))
+        self.choose_line_or_trafo.addWidget(self.choose_line)
+        self.choose_line_or_trafo.addWidget(self.choose_trafo)
 
-        self.chosenLineFormLayout = QFormLayout()
+        self.chosen_line_form_layout = QFormLayout()
 
-        self.chooseLineModel = QComboBox()
-        self.chooseLineModel.addItem('No model')
+        self.choose_line_model = QComboBox()
+        self.choose_line_model.addItem("No model")
 
-        self.EllLineEdit = QLineEdit()
-        self.EllLineEdit.setValidator(QDoubleValidator(bottom=0.))
+        self.ell_line_edit = QLineEdit()
+        self.ell_line_edit.setValidator(QDoubleValidator(bottom=0.))
 
-        self.VbaseLineEdit = QLineEdit()
-        self.VbaseLineEdit.setValidator(QDoubleValidator(bottom=0.))
+        self.vbase_line_edit = QLineEdit()
+        self.vbase_line_edit.setValidator(QDoubleValidator(bottom=0.))
 
-        self.TlRLineEdit = QLineEdit()
-        self.TlRLineEdit.setValidator(QDoubleValidator(bottom=0.))
+        self.tl_r_line_edit = QLineEdit()
+        self.tl_r_line_edit.setValidator(QDoubleValidator(bottom=0.))
 
-        self.TlXLineEdit = QLineEdit()
-        self.TlXLineEdit.setValidator(QDoubleValidator(bottom=0.))
+        self.tl_x_line_edit = QLineEdit()
+        self.tl_x_line_edit.setValidator(QDoubleValidator(bottom=0.))
 
-        self.TlYLineEdit = QLineEdit()
-        self.TlYLineEdit.setValidator(QDoubleValidator(bottom=0.))
+        self.tl_b_line_edit = QLineEdit()
+        self.tl_b_line_edit.setValidator(QDoubleValidator(bottom=0.))
 
-        self.tlSubmitByImpedancePushButton = QPushButton('Submit by impedance')
-        self.tlSubmitByImpedancePushButton.setMinimumWidth(self.sidebar_width)
-        self.tlSubmitByImpedancePushButton.setMaximumWidth(self.sidebar_width)
-        self.tlSubmitByImpedancePushButton.pressed.connect(lambda: self.lineProcessing('impedance'))
+        self.tl_submit_by_impedance_button = QPushButton("Submit by impedance")
+        self.tl_submit_by_impedance_button.setMinimumWidth(self.sidebar_width)
+        self.tl_submit_by_impedance_button.setMaximumWidth(self.sidebar_width)
+        self.tl_submit_by_impedance_button.pressed.connect(lambda: self.submit_line('impedance'))
 
-        self.tlSubmitByModelPushButton = QPushButton('Submit by model')
-        self.tlSubmitByModelPushButton.pressed.connect(lambda: self.lineProcessing('parameters'))
-        self.tlSubmitByModelPushButton.setMinimumWidth(self.sidebar_width)
-        self.tlSubmitByModelPushButton.setMaximumWidth(self.sidebar_width)
+        self.tl_submit_by_model_button = QPushButton("Submit by model")
+        self.tl_submit_by_model_button.pressed.connect(lambda: self.submit_line('parameters'))
+        self.tl_submit_by_model_button.setMinimumWidth(self.sidebar_width)
+        self.tl_submit_by_model_button.setMaximumWidth(self.sidebar_width)
 
-        self.chosenLineFormLayout.addRow('Model', self.chooseLineModel)
-        self.chosenLineFormLayout.addRow('\u2113 (km)', self.EllLineEdit)
-        self.chosenLineFormLayout.addRow('Vbase (kV)', self.VbaseLineEdit)
-        self.chosenLineFormLayout.addRow('R (%pu)', self.TlRLineEdit)
-        self.chosenLineFormLayout.addRow('X<sub>L</sub> (%pu)', self.TlXLineEdit)
-        self.chosenLineFormLayout.addRow('B<sub>C</sub> (%pu)', self.TlYLineEdit)
+        self.chosen_line_form_layout.addRow("Model", self.choose_line_model)
+        self.chosen_line_form_layout.addRow("\u2113 (km)", self.ell_line_edit)
+        self.chosen_line_form_layout.addRow("Vbase (kV)", self.vbase_line_edit)
+        self.chosen_line_form_layout.addRow("R (%pu)", self.tl_r_line_edit)
+        self.chosen_line_form_layout.addRow("X<sub>L</sub> (%pu)", self.tl_x_line_edit)
+        self.chosen_line_form_layout.addRow("B<sub>C</sub> (%pu)", self.tl_b_line_edit)
 
-        self.removeTLPushButton = QPushButton('Remove TL')
-        self.removeTLPushButton.setMinimumWidth(self.sidebar_width)
-        self.removeTLPushButton.setMaximumWidth(self.sidebar_width)
-        self.removeTLPushButton.pressed.connect(self.remove_line)
+        self.remove_tl_push_button = QPushButton('Remove TL')
+        self.remove_tl_push_button.setMinimumWidth(self.sidebar_width)
+        self.remove_tl_push_button.setMaximumWidth(self.sidebar_width)
+        self.remove_tl_push_button.pressed.connect(self.remove_line)
         """" 
         # Reason of direct button bind to self.LayoutManager: 
         #     The layout should disappear only when a line or trafo is excluded.
         #     The conversion trafo <-> line calls the method remove_selected_(line/trafo)
         """
-        self.removeTLPushButton.pressed.connect(self.LayoutManager)
+        self.remove_tl_push_button.pressed.connect(self.update_layout)
 
-        self.chosenTrafoFormLayout = QFormLayout()
-        self.SNomTrafoLineEdit = QLineEdit()
-        self.SNomTrafoLineEdit.setValidator(QDoubleValidator(bottom=0.))
-        self.XZeroSeqTrafoLineEdit = QLineEdit()
-        self.XZeroSeqTrafoLineEdit.setValidator(QDoubleValidator(bottom=0.))
-        self.XPosSeqTrafoLineEdit = QLineEdit()
-        self.XPosSeqTrafoLineEdit.setValidator(QDoubleValidator(bottom=0.))
+        self.chosen_trafo_form_layout = QFormLayout()
+        self.snom_trafo_line_edit = QLineEdit()
+        self.snom_trafo_line_edit.setValidator(QDoubleValidator(bottom=0.))
+        self.x_zero_seq_trafo_line_edit = QLineEdit()
+        self.x_zero_seq_trafo_line_edit.setValidator(QDoubleValidator(bottom=0.))
+        self.x_pos_seq_trafo_line_edit = QLineEdit()
+        self.x_pos_seq_trafo_line_edit.setValidator(QDoubleValidator(bottom=0.))
 
-        self.TrafoPrimary = QComboBox()
-        self.TrafoPrimary.addItem('Y')
-        self.TrafoPrimary.addItem('Y\u23DA')
-        self.TrafoPrimary.addItem('\u0394')
-        self.TrafoSecondary = QComboBox()
-        self.TrafoSecondary.addItem('Y')
-        self.TrafoSecondary.addItem('Y\u23DA')
-        self.TrafoSecondary.addItem('\u0394')
+        self.trafo_primary = QComboBox()
+        self.trafo_primary.addItem('Y')
+        self.trafo_primary.addItem('Y\u23DA')
+        self.trafo_primary.addItem('\u0394')
+        self.trafo_secondary = QComboBox()
+        self.trafo_secondary.addItem('Y')
+        self.trafo_secondary.addItem('Y\u23DA')
+        self.trafo_secondary.addItem('\u0394')
 
-        self.trafoSubmitPushButton = QPushButton('Submit trafo')
-        self.trafoSubmitPushButton.pressed.connect(self.trafoProcessing)
-        self.trafoSubmitPushButton.setMinimumWidth(self.sidebar_width)
-        self.trafoSubmitPushButton.setMaximumWidth(self.sidebar_width)
+        self.trafo_submit_push_button = QPushButton('Submit trafo')
+        self.trafo_submit_push_button.pressed.connect(self.submit_trafo)
+        self.trafo_submit_push_button.setMinimumWidth(self.sidebar_width)
+        self.trafo_submit_push_button.setMaximumWidth(self.sidebar_width)
 
-        self.removeTrafoPushButton = QPushButton('Remove trafo')
-        self.removeTrafoPushButton.pressed.connect(self.remove_trafo)
+        self.remove_trafo_push_button = QPushButton('Remove trafo')
+        self.remove_trafo_push_button.pressed.connect(self.remove_trafo)
         """" 
         # Reason of direct button bind to self.LayoutManager: 
         #     The layout should disappear only when a line or trafo is excluded.
         #     The conversion trafo <-> line calls the method remove_selected_(line/trafo)
         """
-        self.removeTrafoPushButton.pressed.connect(self.LayoutManager)
-        self.removeTrafoPushButton.setMinimumWidth(self.sidebar_width)
-        self.removeTrafoPushButton.setMaximumWidth(self.sidebar_width)
+        self.remove_trafo_push_button.pressed.connect(self.update_layout)
+        self.remove_trafo_push_button.setMinimumWidth(self.sidebar_width)
+        self.remove_trafo_push_button.setMaximumWidth(self.sidebar_width)
 
-        self.chosenTrafoFormLayout.addRow('Snom (MVA)', self.SNomTrafoLineEdit)
-        self.chosenTrafoFormLayout.addRow('x+ (%pu)', self.XPosSeqTrafoLineEdit)
-        self.chosenTrafoFormLayout.addRow('x0 (%pu)', self.XZeroSeqTrafoLineEdit)
-        self.chosenTrafoFormLayout.addRow('Prim.', self.TrafoPrimary)
-        self.chosenTrafoFormLayout.addRow('Sec.', self.TrafoSecondary)
+        self.chosen_trafo_form_layout.addRow("Snom (MVA)", self.snom_trafo_line_edit)
+        self.chosen_trafo_form_layout.addRow("x+ (%pu)", self.x_pos_seq_trafo_line_edit)
+        self.chosen_trafo_form_layout.addRow("x0 (%pu)", self.x_zero_seq_trafo_line_edit)
+        self.chosen_trafo_form_layout.addRow("Prim.", self.trafo_primary)
+        self.chosen_trafo_form_layout.addRow("Sec.", self.trafo_secondary)
 
-        self.LineOrTrafoLayout.addLayout(self.chooseLineOrTrafo)
-        self.LineOrTrafoLayout.addLayout(self.chosenLineFormLayout)
-        self.LineOrTrafoLayout.addLayout(self.chosenTrafoFormLayout)
+        self.line_or_trafo_layout.addLayout(self.choose_line_or_trafo)
+        self.line_or_trafo_layout.addLayout(self.chosen_line_form_layout)
+        self.line_or_trafo_layout.addLayout(self.chosen_trafo_form_layout)
 
         # Submit and remove buttons for line
-        self.LineOrTrafoLayout.addWidget(self.tlSubmitByModelPushButton)
-        self.LineOrTrafoLayout.addWidget(self.tlSubmitByImpedancePushButton)
-        self.LineOrTrafoLayout.addWidget(self.removeTLPushButton)
+        self.line_or_trafo_layout.addWidget(self.tl_submit_by_model_button)
+        self.line_or_trafo_layout.addWidget(self.tl_submit_by_impedance_button)
+        self.line_or_trafo_layout.addWidget(self.remove_tl_push_button)
 
         # Buttons submit and remove button for trafo
-        self.LineOrTrafoLayout.addWidget(self.trafoSubmitPushButton)
-        self.LineOrTrafoLayout.addWidget(self.removeTrafoPushButton)
+        self.line_or_trafo_layout.addWidget(self.trafo_submit_push_button)
+        self.line_or_trafo_layout.addWidget(self.remove_trafo_push_button)
 
         # Layout that holds bus inspector and Stretches
-        self.InspectorAreaLayout = QVBoxLayout()
-        self.InspectorLayout.addStretch()
-        self.InspectorLayout.addLayout(self.BusLayout)
-        self.InspectorLayout.addLayout(self.LineOrTrafoLayout)
-        self.InspectorLayout.addStretch()
-        self.InspectorAreaLayout.addLayout(self.InspectorLayout)
+        self.sidebar_layout = QVBoxLayout()
+        self.inspector_layout.addStretch()
+        self.inspector_layout.addLayout(self.bus_layout)
+        self.inspector_layout.addLayout(self.line_or_trafo_layout)
+        self.inspector_layout.addStretch()
+        self.sidebar_layout.addLayout(self.inspector_layout)
 
         # Toplayout
-        self.TopLayout = QHBoxLayout()
-        self.Spacer = QSpacerItem(self.sidebar_width, 0, QSizePolicy.Fixed, QSizePolicy.Fixed)
-        self.TopLayout.addItem(self.Spacer)
-        self.TopLayout.addLayout(self.InspectorAreaLayout)
-        self.TopLayout.addLayout(self.SchemeInputLayout)
-        self.TopLayout.addLayout(self.InputNewLineType)
-        self.TopLayout.addLayout(self.ControlPanelLayout)
-        self.setLayout(self.TopLayout)
+        self.top_layout = QHBoxLayout()
+        self.spacer = QSpacerItem(self.sidebar_width, 0, QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.top_layout.addItem(self.spacer)
+        self.top_layout.addLayout(self.sidebar_layout)
+        self.top_layout.addLayout(self.editor_layout)
+        self.top_layout.addLayout(self.new_line_type)
+        self.top_layout.addLayout(self.control_panel_layout)
+        self.setLayout(self.top_layout)
 
         # All layouts hidden at first moment
-        self.setLayoutHidden(self.BusLayout, True)
-        self.setLayoutHidden(self.LineOrTrafoLayout, True)
-        self.setLayoutHidden(self.InputNewLineType, True)
-        self.setLayoutHidden(self.ControlPanelLayout, True)
-        self.showSpacer()
+        self.clear_layout(self.bus_layout, True)
+        self.clear_layout(self.line_or_trafo_layout, True)
+        self.clear_layout(self.new_line_type, True)
+        self.clear_layout(self.control_panel_layout, True)
+        self.show_spacer()
 
-    def methodsTrigger(self, args):
+    def methods_trigger(self, args):
         """Trigger methods defined in __calls"""
         self.__calls[args]()
 
-    def setCurrentObject(self, args):
+    def set_current_coord(self, args):
         """Define coordinates pointing to current selected object in interface"""
-        self._currElementCoords = args
+        self._curr_element_coord = args
 
-    def hideSpacer(self):
-        self.Spacer.changeSize(0, 0)
+    def hide_spacer(self):
+        self.spacer.changeSize(0, 0)
 
-    def showSpacer(self):
-        self.Spacer.changeSize(self.sidebar_width, 0)
+    def show_spacer(self):
+        self.spacer.changeSize(self.sidebar_width, 0)
 
-    def setTemp(self, args):
+    def set_temp(self, args):
         """This method stores the first line in line element drawing during line inputting.
         Its existence is justified by the first square limitation in MouseMoveEvent
         """
         self._temp = args
 
-    def storeOriginAddLine(self):
-        if self._startNewTL:
-            self._line_origin = self._currElementCoords
+    def store_line_origin(self):
+        if self._start_line:
+            self._line_origin = self._curr_element_coord
 
-    def setLayoutHidden(self, layout, visible):
+    def clear_layout(self, layout, visible):
         """Hide completely any layout containing widgets or/and other layouts"""
-        witems = list(layout.itemAt(i).widget() for i in range(layout.count())
-                      if not isinstance(layout.itemAt(i), QLayout))
-        witems = list(filter(lambda x: x is not None, witems))
-        for w in witems:
+        widgets = list(layout.itemAt(i).widget() for i in range(layout.count())
+                       if not isinstance(layout.itemAt(i), QLayout))
+        widgets = list(filter(lambda x: x is not None, widgets))
+        for w in widgets:
             w.setHidden(visible)
-        litems = list(layout.itemAt(i).layout() for i in range(layout.count()) if isinstance(layout.itemAt(i), QLayout))
-        for children_layout in litems:
-            self.setLayoutHidden(children_layout, visible)
+        layouts = list(layout.itemAt(i).layout() for i in range(layout.count())
+                       if isinstance(layout.itemAt(i), QLayout))
+        for child_layout in layouts:
+            self.clear_layout(child_layout, visible)
 
-    def updateNmaxLabel(self, nmax):
-        self.NmaxLabel.setText('Nmax: {}'.format(nmax).zfill(2))
+    def update_nmax_label(self, nmax):
+        self.nmax_label.setText("Nmax: {:02d}".format(nmax))
 
-    def updateNmaxSlider(self, nmax):
-        self.NmaxSlider.setEnabled(True)
-        self.NmaxSlider.setValue(nmax)
+    def update_nmax_slider(self, nmax):
+        self.nmax_slider.setEnabled(True)
+        self.nmax_slider.setValue(nmax)
 
-    def setNmaxValue(self, nmax):
-        self.nmax = nmax
-        self.updateNmaxLabel(self.nmax)
+    def set_nmax(self, nmax):
+        self.max_niter = nmax
+        self.update_nmax_label(self.max_niter)
 
-    def getBusFromGridPos(self, coords):
-        """Returns a Bus object that occupies grid in `coords` position"""
-        grid_bus = self.Scene.grid[coords]
+    def bus_at(self, coord):
+        """Returns a Bus object that occupies grid in `coord` position"""
+        grid_bus = self.editor.bus_grid[coord]
         if isinstance(grid_bus, Bus):
             return grid_bus
         return None
 
-    def getCurveFromGridPos(self, coords):
-        """Returns a LineSegment object that has `coords` in its coordinates"""
+    def curve_at(self, coord):
+        """Returns a LineSegment object that has `coord` in its coordinates"""
         for curve in self.curves:
-            if coords in curve.coords:
+            if coord in curve.coords:
                 return curve
         return None
 
-    def checkLineAndTrafoCrossing(self):
+    def are_lines_crossing(self):
         """Searches for crossing between current inputting line/trafo and existent line/trafo"""
+        is_bus = isinstance(self.editor.bus_grid[self._curr_element_coord], Bus)
         for curve in self.curves:
-            if self._currElementCoords in curve.coords and not isinstance(self.Scene.grid[self._currElementCoords],
-                                                                          Bus):
+            if self._curr_element_coord in curve.coords and not is_bus:
                 return True
         return False
 
     def add_segment(self):
-        if self._startNewTL:
-            bus_orig = self.Scene.grid[self._line_origin]
+        if self._start_line:
+            bus_orig = self.editor.bus_grid[self._line_origin]
             new_line = TransmissionLine(orig=bus_orig, dest=None)
             new_curve = LineSegment(obj=new_line,
-                                    coords=[self._line_origin, self._currElementCoords],
+                                    coords=[self._line_origin,
+                                            self._curr_element_coord],
                                     dlines=[self._temp])
-            if self.checkLineAndTrafoCrossing():
+            if self.are_lines_crossing():
                 new_curve.remove = True
             self.curves.append(new_curve)
         else:
             curr_curve = self.curves[-1]
-            if self.checkLineAndTrafoCrossing():
+            if self.are_lines_crossing():
                 curr_curve.remove = True
             curr_curve.dlines.append(self._temp)
-            curr_curve.coords.append(self._currElementCoords)
-            if isinstance(self.Scene.grid[self._currElementCoords], Bus):
+            curr_curve.coords.append(self._curr_element_coord)
+            if isinstance(self.editor.bus_grid[self._curr_element_coord], Bus):
                 if curr_curve.obj.dest is None:
-                    bus_dest = self.Scene.grid[self._currElementCoords]
+                    bus_dest = self.editor.bus_grid[self._curr_element_coord]
                     curr_curve.obj.dest = bus_dest
-        self._startNewTL = False
-        self.statusMsg.emit_sig('Adding line...')
+        self._start_line = False
+        self.status_msg.emit_sig("Adding line...")
 
-    def findParametersSetFromLt(self, line):
+    def find_line_model_from_object(self, line):
         """Return the name of parameters set of a existent line or
         return None if the line has been set by impedance and admittance
         """
@@ -715,47 +726,49 @@ class CircuitInputer(QWidget):
                 return line_name
         return "No model"
 
-    def findParametersSetFromComboBox(self):
+    def find_line_model_from_text(self):
         """Find parameters set based on current selected line or trafo inspector combo box
         If the line was set with impedance/admittance, return 'None'
         """
-        set_name = self.chooseLineModel.currentText()
+        set_name = self.choose_line_model.currentText()
         for line_name, line_model in self.line_types.items():
             if set_name == line_name:
                 return line_model
         return None
 
-    def addNewLineType(self):
+    def add_new_line_model(self):
         """Add a new type of line, if given parameters has passed in all the tests
         Called by: SubmitNewLineTypePushButton.pressed"""
-        name = self.ModelName.text()
-        float_or_nan = lambda s: np.nan if s == '' else float(s)
+        name = self.model_name.text()
+
+        def float_or_nan(s):
+            return np.nan if s == '' else float(s)
         new_param = dict(
-            r=float_or_nan(self.rLineEdit.text()) / 1e3,
-            d12=float_or_nan(self.d12LineEdit.text()),
-            d23=float_or_nan(self.d23LineEdit.text()),
-            d31=float_or_nan(self.d31LineEdit.text()),
-            d=float_or_nan(self.dLineEdit.text()),
-            rho=float_or_nan(self.RhoLineEdit.text()) / 1e9,
-            m=float_or_nan(self.mLineEdit.text()),
-            imax=float_or_nan(self.imaxLineEdit.text())
+            r=float_or_nan(self.r_line_edit.text()) / 1e3,
+            d12=float_or_nan(self.d12_line_edit.text()),
+            d23=float_or_nan(self.d23_line_edit.text()),
+            d31=float_or_nan(self.d31_line_edit.text()),
+            d=float_or_nan(self.d_line_edit.text()),
+            rho=float_or_nan(self.rho_line_edit.text()) / 1e9,
+            m=float_or_nan(self.m_line_edit.text()),
+            imax=float_or_nan(self.imax_line_edit.text())
         )
         line = TransmissionLine(orig=None, dest=None)
         line.__dict__.update(new_param)
         if name in self.line_types.keys():
-            self.statusMsg.emit_sig('Duplicated name. Insert another valid name')
+            self.status_msg.emit_sig('Duplicated name. Insert another valid name')
             return
         if any(np.isnan(list(new_param.values()))):
-            self.statusMsg.emit_sig('Undefined parameter. Fill all parameters')
+            self.status_msg.emit_sig('Undefined parameter. Fill all parameters')
             return
         if any(map(lambda x: line.param == x.param, self.line_types.values())):
-            self.statusMsg.emit_sig('A similar model was identified. The model has not been stored')
+            self.status_msg.emit_sig('A similar model was identified. The model has not been stored')
             return
         self.line_types[name] = line
-        self.statusMsg.emit_sig('The model has been stored')
+        self.status_msg.emit_sig('The model has been stored')
 
     @staticmethod
-    def updateLineWithParameters(line, param_values, ell, vbase):
+    def submit_line_by_model(line, param_values, ell, vbase):
         """Update a line with parameters
 
         Parameters
@@ -771,7 +784,7 @@ class CircuitInputer(QWidget):
         line.ell = ell
 
     @staticmethod
-    def updateLineWithImpedances(line, Z, Y, ell, vbase):
+    def submit_line_by_impedance(line, Z, Y, ell, vbase):
         """Update a line with impedance/admittance
 
         Parameters
@@ -788,75 +801,75 @@ class CircuitInputer(QWidget):
         line.vbase = vbase
         line.m = 0
 
-    def updateLineModelOptions(self):
+    def update_line_model_options(self):
         """Add the name of a new parameter set to QComboBox choose model,
            if the Combo has not the model yet
         -----------------------------------------------------------------
         """
         for line_name in self.line_types.keys():
-            if self.chooseLineModel.isVisible() and self.chooseLineModel.findText(line_name) < 0:
-                self.chooseLineModel.addItem(line_name)
+            if self.choose_line_model.isVisible() and self.choose_line_model.findText(line_name) < 0:
+                self.choose_line_model.addItem(line_name)
 
-    def defineLineOrTrafoVisibility(self):
+    def toggle_line_trafo(self):
         """Show line or trafo options in adding line/trafo section"""
-        if not self.chooseLine.isHidden() and not self.chooseTrafo.isHidden():
-            if self.chooseLine.isChecked():
+        if not self.choose_line.isHidden() and not self.choose_trafo.isHidden():
+            if self.choose_line.isChecked():
                 # Line
-                self.setLayoutHidden(self.chosenLineFormLayout, False)
-                self.setLayoutHidden(self.chosenTrafoFormLayout, True)
-                self.removeTLPushButton.setHidden(False)
-                self.tlSubmitByImpedancePushButton.setHidden(False)
-                self.tlSubmitByModelPushButton.setHidden(False)
-                self.trafoSubmitPushButton.setHidden(True)
-                self.removeTrafoPushButton.setHidden(True)
-            elif self.chooseTrafo.isChecked():
+                self.clear_layout(self.chosen_line_form_layout, False)
+                self.clear_layout(self.chosen_trafo_form_layout, True)
+                self.remove_tl_push_button.setHidden(False)
+                self.tl_submit_by_impedance_button.setHidden(False)
+                self.tl_submit_by_model_button.setHidden(False)
+                self.trafo_submit_push_button.setHidden(True)
+                self.remove_trafo_push_button.setHidden(True)
+            elif self.choose_trafo.isChecked():
                 # Trafo
-                self.setLayoutHidden(self.chosenLineFormLayout, True)
-                self.setLayoutHidden(self.chosenTrafoFormLayout, False)
-                self.removeTLPushButton.setHidden(True)
-                self.tlSubmitByImpedancePushButton.setHidden(True)
-                self.tlSubmitByModelPushButton.setHidden(True)
-                self.trafoSubmitPushButton.setHidden(False)
-                self.removeTrafoPushButton.setHidden(False)
+                self.clear_layout(self.chosen_line_form_layout, True)
+                self.clear_layout(self.chosen_trafo_form_layout, False)
+                self.remove_tl_push_button.setHidden(True)
+                self.tl_submit_by_impedance_button.setHidden(True)
+                self.tl_submit_by_model_button.setHidden(True)
+                self.trafo_submit_push_button.setHidden(False)
+                self.remove_trafo_push_button.setHidden(False)
 
-    def updateTrafoInspector(self):
+    def trafo_menu(self):
         """Update trafo inspector
         Calls
         -----
         LayoutManager, trafoProcessing
         """
-        curve = self.getCurveFromGridPos(self._currElementCoords)
+        curve = self.curve_at(self._curr_element_coord)
         if curve is not None:
             trafo = curve.obj
-            self.SNomTrafoLineEdit.setText('{:.3g}'.format(trafo.snom / 1e6))
-            self.XZeroSeqTrafoLineEdit.setText('{:.3g}'.format(trafo.jx0 * 100))
-            self.XPosSeqTrafoLineEdit.setText('{:.3g}'.format(trafo.jx1 * 100))
-            self.TrafoPrimary.setCurrentText(PY_TO_SYMBOL[trafo.primary])
-            self.TrafoSecondary.setCurrentText(PY_TO_SYMBOL[trafo.secondary])
+            self.snom_trafo_line_edit.setText('{:.3g}'.format(trafo.snom / 1e6))
+            self.x_zero_seq_trafo_line_edit.setText('{:.3g}'.format(trafo.jx0 * 100))
+            self.x_pos_seq_trafo_line_edit.setText('{:.3g}'.format(trafo.jx1 * 100))
+            self.trafo_primary.setCurrentText(PY_TO_SYMBOL[trafo.primary])
+            self.trafo_secondary.setCurrentText(PY_TO_SYMBOL[trafo.secondary])
         else:
-            self.SNomTrafoLineEdit.setText('100')
-            self.XZeroSeqTrafoLineEdit.setText('0.0')
-            self.XPosSeqTrafoLineEdit.setText('0.0')
-            self.TrafoPrimary.setCurrentText(PY_TO_SYMBOL[1])
-            self.TrafoSecondary.setCurrentText(PY_TO_SYMBOL[1])
+            self.snom_trafo_line_edit.setText('100')
+            self.x_zero_seq_trafo_line_edit.setText('0.0')
+            self.x_pos_seq_trafo_line_edit.setText('0.0')
+            self.trafo_primary.setCurrentText(PY_TO_SYMBOL[1])
+            self.trafo_secondary.setCurrentText(PY_TO_SYMBOL[1])
 
-    def updateLineInspector(self):
+    def line_menu(self):
         """Updates the line inspector
         Calls
         -----
         LayoutManager, lineProcessing
         """
-        curve = self.getCurveFromGridPos(self._currElementCoords)
+        curve = self.curve_at(self._curr_element_coord)
         line = curve.obj
-        line_model = self.findParametersSetFromLt(line)
-        self.EllLineEdit.setText('{:.03g}'.format(line.ell / 1e3))
-        self.VbaseLineEdit.setText('{:.03g}'.format(line.vbase / 1e3))
-        self.TlRLineEdit.setText('{number.real:.04f}'.format(number=line.Zpu * 100))
-        self.TlXLineEdit.setText('{number.imag:.04f}'.format(number=line.Zpu * 100))
-        self.TlYLineEdit.setText('{number.imag:.04f}'.format(number=line.Ypu * 100))
-        self.chooseLineModel.setCurrentText(line_model)
+        line_model = self.find_line_model_from_object(line)
+        self.ell_line_edit.setText('{:.03g}'.format(line.ell / 1e3))
+        self.vbase_line_edit.setText('{:.03g}'.format(line.vbase / 1e3))
+        self.tl_r_line_edit.setText('{number.real:.04f}'.format(number=line.Zpu * 100))
+        self.tl_x_line_edit.setText('{number.imag:.04f}'.format(number=line.Zpu * 100))
+        self.tl_b_line_edit.setText('{number.imag:.04f}'.format(number=line.Ypu * 100))
+        self.choose_line_model.setCurrentText(line_model)
 
-    def updateBusInspector(self, bus):
+    def bus_menu(self, bus):
         """Updates the bus inspector with bus data if bus exists or
         shows that there's no bus (only after bus exclusion)
         Called by: LayoutManager, remove_gen, remove_load
@@ -865,116 +878,118 @@ class CircuitInputer(QWidget):
         ----------
         bus: Bus object whose data will be displayed
         """
-        to_be_disabled = [self.PgInput,
-                          self.PlInput,
-                          self.QlInput,
-                          self.BusV_Value,
-                          self.XdLineEdit,
-                          self.LoadGround,
-                          self.GenGround]
+        to_be_disabled = [self.pg_input,
+                          self.pl_input,
+                          self.ql_input,
+                          self.bus_v_value,
+                          self.xd_line_edit,
+                          self.load_ground,
+                          self.gen_ground]
         for item in to_be_disabled:
             item.setDisabled(True)
         if bus:
             if bus.bus_id == 0:
-                self.BusTitle.setText('Slack')
+                self.bus_title.setText("Slack")
             else:
-                self.BusTitle.setText('Bus {}'.format(bus.bus_id + 1))
+                self.bus_title.setText("Bus {}".format(bus.bus_id + 1))
             if bus.pl > 0 or bus.ql > 0:
-                self.AddLoadButton.setText('-')
-                self.AddLoadButton.disconnect()
-                self.AddLoadButton.pressed.connect(self.remove_load)
-                self.LoadGround.setCurrentText(PY_TO_SYMBOL[bus.load_ground])
+                self.add_load_button.setText('-')
+                self.add_load_button.disconnect()
+                self.add_load_button.pressed.connect(self.remove_load)
+                self.load_ground.setCurrentText(PY_TO_SYMBOL[bus.load_ground])
             else:
-                self.AddLoadButton.setText('+')
-                self.AddLoadButton.disconnect()
-                self.AddLoadButton.pressed.connect(self.add_load)
-                self.LoadGround.setCurrentText(PY_TO_SYMBOL[EARTH])
+                self.add_load_button.setText('+')
+                self.add_load_button.disconnect()
+                self.add_load_button.pressed.connect(self.add_load)
+                self.load_ground.setCurrentText(PY_TO_SYMBOL[EARTH])
             if (bus.pg > 0 or bus.qg > 0) and bus.bus_id > 0:
-                self.AddGenerationButton.setText('-')
-                self.AddGenerationButton.disconnect()
-                self.AddGenerationButton.pressed.connect(self.remove_gen)
+                self.add_generation_button.setText('-')
+                self.add_generation_button.disconnect()
+                self.add_generation_button.pressed.connect(self.remove_gen)
             elif bus.bus_id == 0:
-                self.AddGenerationButton.setText('EDIT')
-                self.AddGenerationButton.disconnect()
-                self.AddGenerationButton.pressed.connect(self.add_gen)
+                self.add_generation_button.setText('EDIT')
+                self.add_generation_button.disconnect()
+                self.add_generation_button.pressed.connect(self.add_gen)
             else:
-                self.AddGenerationButton.setText('+')
-                self.AddGenerationButton.disconnect()
-                self.AddGenerationButton.pressed.connect(self.add_gen)
-            self.BusV_Value.setText('{:.3g}'.format(bus.v))
-            self.BusAngle_Value.setText('{:.3g}'.format(bus.delta * 180 / np.pi))
-            self.QgInput.setText('{:.4g}'.format(bus.qg * 100))
-            self.PgInput.setText('{:.4g}'.format(bus.pg * 100))
-            self.QlInput.setText('{:.4g}'.format(bus.ql * 100))
-            self.PlInput.setText('{:.4g}'.format(bus.pl * 100))
-            self.XdLineEdit.setText('{:.3g}'.format(bus.xd))
-            self.GenGround.setChecked(bus.gen_ground)
+                self.add_generation_button.setText('+')
+                self.add_generation_button.disconnect()
+                self.add_generation_button.pressed.connect(self.add_gen)
+            self.bus_v_value.setText("{:.3g}".format(bus.v))
+            self.bus_angle_value.setText("{:.3g}".format(bus.delta * 180 / np.pi))
+            self.qg_input.setText("{:.4g}".format(bus.qg * 100))
+            self.pg_input.setText("{:.4g}".format(bus.pg * 100))
+            self.ql_input.setText("{:.4g}".format(bus.ql * 100))
+            self.pl_input.setText("{:.4g}".format(bus.pl * 100))
+            self.xd_line_edit.setText("{:.3g}".format(bus.xd))
+            self.gen_ground.setChecked(bus.gen_ground)
 
         if bus.xd == np.inf:
-            self.XdLineEdit.setText('\u221E')
+            self.xd_line_edit.setText("\u221E")
         else:
-            self.XdLineEdit.setText('{:.3g}'.format(bus.xd * 100))
+            self.xd_line_edit.setText("{:.3g}".format(bus.xd * 100))
 
-    def LayoutManager(self):
-        """Hide or show specific layouts, based on the current element or passed parameters by trigger methods.
-        Called two times ever because self.doAfterMouseRelease is triggered whenever the mouse is released
+    def update_layout(self):
+        """Hide or show specific layouts, based on the current element or
+        passed parameters by trigger methods.
+        Called two times ever because self.doAfterMouseRelease is triggered
+        whenever the mouse is released
         ------------------------------------------------------------------------------------------------------
         Called by: doAfterMouseRelease
         ------------------------------------------------------------------------------------------------------
         """
 
-        # Even if there are two elements in a same square, only one will be identified
+        # Even if there are two elements in the same square, only one will be identified
         # Bus has high priority
         # After, lines and trafo have equal priority
-        bus = self.getBusFromGridPos(self._currElementCoords)
-        curve = self.getCurveFromGridPos(self._currElementCoords)
+        bus = self.bus_at(self._curr_element_coord)
+        curve = self.curve_at(self._curr_element_coord)
         if bus is not None:
             # Show bus inspect
-            self.hideSpacer()
-            self.setLayoutHidden(self.InputNewLineType, True)
-            self.setLayoutHidden(self.LineOrTrafoLayout, True)
-            self.setLayoutHidden(self.ControlPanelLayout, True)
-            self.setLayoutHidden(self.BusLayout, False)
-            self.updateBusInspector(bus)
+            self.hide_spacer()
+            self.clear_layout(self.new_line_type, True)
+            self.clear_layout(self.line_or_trafo_layout, True)
+            self.clear_layout(self.control_panel_layout, True)
+            self.clear_layout(self.bus_layout, False)
+            self.bus_menu(bus)
         elif curve is not None:
             if isinstance(curve.obj, TransmissionLine):
                 # Show line inspect
-                self.hideSpacer()
-                self.setLayoutHidden(self.InputNewLineType, True)
-                self.setLayoutHidden(self.BusLayout, True)
-                self.setLayoutHidden(self.LineOrTrafoLayout, False)
-                self.chooseLine.setChecked(True)
-                self.setLayoutHidden(self.chosenTrafoFormLayout, True)
-                self.setLayoutHidden(self.chosenLineFormLayout, False)
-                self.trafoSubmitPushButton.setHidden(True)
-                self.removeTrafoPushButton.setHidden(True)
-                self.setLayoutHidden(self.ControlPanelLayout, True)
-                self.removeTLPushButton.setHidden(False)
-                self.updateLineModelOptions()
-                self.updateLineInspector()
+                self.hide_spacer()
+                self.clear_layout(self.new_line_type, True)
+                self.clear_layout(self.bus_layout, True)
+                self.clear_layout(self.line_or_trafo_layout, False)
+                self.choose_line.setChecked(True)
+                self.clear_layout(self.chosen_trafo_form_layout, True)
+                self.clear_layout(self.chosen_line_form_layout, False)
+                self.trafo_submit_push_button.setHidden(True)
+                self.remove_trafo_push_button.setHidden(True)
+                self.clear_layout(self.control_panel_layout, True)
+                self.remove_tl_push_button.setHidden(False)
+                self.update_line_model_options()
+                self.line_menu()
             elif isinstance(curve.obj, Transformer):
                 # Show trafo inspect
-                self.setLayoutHidden(self.InputNewLineType, True)
-                self.hideSpacer()
-                self.setLayoutHidden(self.BusLayout, True)
-                self.setLayoutHidden(self.LineOrTrafoLayout, False)
-                self.chooseTrafo.setChecked(True)
-                self.setLayoutHidden(self.chosenTrafoFormLayout, False)
-                self.setLayoutHidden(self.chosenLineFormLayout, True)
-                self.trafoSubmitPushButton.setHidden(False)
-                self.removeTrafoPushButton.setHidden(False)
-                self.removeTLPushButton.setHidden(True)
-                self.tlSubmitByModelPushButton.setHidden(True)
-                self.tlSubmitByImpedancePushButton.setHidden(True)
-                self.setLayoutHidden(self.ControlPanelLayout, True)
-                self.updateTrafoInspector()
+                self.clear_layout(self.new_line_type, True)
+                self.hide_spacer()
+                self.clear_layout(self.bus_layout, True)
+                self.clear_layout(self.line_or_trafo_layout, False)
+                self.choose_trafo.setChecked(True)
+                self.clear_layout(self.chosen_trafo_form_layout, False)
+                self.clear_layout(self.chosen_line_form_layout, True)
+                self.trafo_submit_push_button.setHidden(False)
+                self.remove_trafo_push_button.setHidden(False)
+                self.remove_tl_push_button.setHidden(True)
+                self.tl_submit_by_model_button.setHidden(True)
+                self.tl_submit_by_impedance_button.setHidden(True)
+                self.clear_layout(self.control_panel_layout, True)
+                self.trafo_menu()
         else:
             # No element case
-            self.setLayoutHidden(self.BusLayout, True)
-            self.setLayoutHidden(self.LineOrTrafoLayout, True)
-            self.setLayoutHidden(self.InputNewLineType, True)
-            self.setLayoutHidden(self.ControlPanelLayout, True)
-            self.showSpacer()
+            self.clear_layout(self.bus_layout, True)
+            self.clear_layout(self.line_or_trafo_layout, True)
+            self.clear_layout(self.new_line_type, True)
+            self.clear_layout(self.control_panel_layout, True)
+            self.show_spacer()
 
     def add_line(self, curve):
         self.curves.append(curve)
@@ -988,17 +1003,17 @@ class CircuitInputer(QWidget):
         """
         Called by: Scene.mouseDoubleClickEvent
         """
-        coords = self._currElementCoords
-        curve = self.getCurveFromGridPos(self._currElementCoords)
-        if not isinstance(self.Scene.grid[coords], Bus) and not curve:
+        coord = self._curr_element_coord
+        curve = self.curve_at(self._curr_element_coord)
+        if not isinstance(self.editor.bus_grid[coord], Bus) and not curve:
             bus = self.system.add_bus()
-            self.Scene.grid[coords] = bus
-            self.statusMsg.emit_sig('Added bus')
+            self.editor.bus_grid[coord] = bus
+            self.status_msg.emit_sig("Added bus")
         else:
-            self.Scene.removeItem(self.Scene.pixmap[coords])
-            self.statusMsg.emit_sig('There\'s an element in this position!')
+            self.editor.removeItem(self.editor.drawings[coord])
+            self.status_msg.emit_sig("There is an element in this position!")
 
-    def lineProcessing(self, mode):
+    def submit_line(self, mode):
         """
         Updates the line parameters based on Y and Z or parameters from LINE_TYPES,
         or converts a trafo into a line and update its parameters following
@@ -1008,60 +1023,60 @@ class CircuitInputer(QWidget):
         ----------
         mode: either 'parameters' or 'impedance'
         """
-        curve = self.getCurveFromGridPos(self._currElementCoords)
+        curve = self.curve_at(self._curr_element_coord)
         if isinstance(curve.obj, TransmissionLine):
             # The element already is a line
             line = curve.obj
             if mode == 'parameters':
-                param_values = self.findParametersSetFromComboBox()
+                param_values = self.find_line_model_from_text()
                 # Current selected element is a line
                 # Update using properties
                 # Z and Y are obtained from the updated properties
                 if param_values is not None:
-                    ell = float(self.EllLineEdit.text()) * 1e3
-                    vbase = float(self.VbaseLineEdit.text()) * 1e3
-                    self.updateLineWithParameters(line, param_values, ell, vbase)
-                    self.LayoutManager()
-                    self.statusMsg.emit_sig('Updated line with parameters')
+                    ell = float(self.ell_line_edit.text()) * 1e3
+                    vbase = float(self.vbase_line_edit.text()) * 1e3
+                    self.submit_line_by_model(line, param_values, ell, vbase)
+                    self.update_layout()
+                    self.status_msg.emit_sig("Updated line with parameters")
                 else:
-                    self.statusMsg.emit_sig('You have to choose a valid model')
+                    self.status_msg.emit_sig("You have to choose a valid model")
             elif mode == 'impedance':
                 # Current selected element is a line
                 # Update using impedance and admittance
-                R = float(self.TlRLineEdit.text()) / 100
-                X = float(self.TlXLineEdit.text()) / 100
-                Y = float(self.TlYLineEdit.text()) / 100
+                R = float(self.tl_r_line_edit.text()) / 100
+                X = float(self.tl_x_line_edit.text()) / 100
+                Y = float(self.tl_b_line_edit.text()) / 100
                 Z = R + 1j * X
                 Y = 1j * Y
-                ell = float(self.EllLineEdit.text()) * 1e3
-                vbase = float(self.VbaseLineEdit.text()) * 1e3
-                self.updateLineWithImpedances(line, Z, Y, ell, vbase)
-                self.LayoutManager()
-                self.statusMsg.emit_sig('Update line with impedances')
+                ell = float(self.ell_line_edit.text()) * 1e3
+                vbase = float(self.vbase_line_edit.text()) * 1e3
+                self.submit_line_by_impedance(line, Z, Y, ell, vbase)
+                self.update_layout()
+                self.status_msg.emit_sig("Update line with impedance")
         elif isinstance(curve.obj, Transformer):
             # The element is a trafo and will be converted into a line
             trafo = curve.obj
             self.remove_trafo(curve)
             new_line = TransmissionLine(orig=trafo.orig, dest=trafo.dest)
             if mode == 'parameters':
-                param_values = self.findParametersSetFromComboBox()
+                param_values = self.find_line_model_from_text()
                 if param_values is not None:
-                    ell = float(self.EllLineEdit.text()) * 1e3
-                    vbase = float(self.VbaseLineEdit.text()) * 1e3
-                    self.updateLineWithParameters(new_line, param_values, ell, vbase)
-                    self.statusMsg.emit_sig('trafo -> line, updated with parameters')
+                    ell = float(self.ell_line_edit.text()) * 1e3
+                    vbase = float(self.vbase_line_edit.text()) * 1e3
+                    self.submit_line_by_model(new_line, param_values, ell, vbase)
+                    self.status_msg.emit_sig("Trafo -> line, updated with parameters")
                 else:
-                    self.statusMsg.emit_sig('You have to choose a valid model')
+                    self.status_msg.emit_sig("You have to choose a valid model")
             elif mode == 'impedance':
-                R = float(self.TlRLineEdit.text()) / 100
-                X = float(self.TlXLineEdit.text()) / 100
-                Y = float(self.TlYLineEdit.text()) / 100
+                R = float(self.tl_r_line_edit.text()) / 100
+                X = float(self.tl_x_line_edit.text()) / 100
+                Y = float(self.tl_b_line_edit.text()) / 100
                 Z = R + 1j * X
                 Y = 1j * Y
-                ell = float(self.EllLineEdit.text()) * 1e3
-                vbase = float(self.VbaseLineEdit.text()) * 1e3
-                self.updateLineWithImpedances(new_line, Z, Y, ell, vbase)
-                self.statusMsg.emit_sig('trafo -> line, updated with impedances')
+                ell = float(self.ell_line_edit.text()) * 1e3
+                vbase = float(self.vbase_line_edit.text()) * 1e3
+                self.submit_line_by_impedance(new_line, Z, Y, ell, vbase)
+                self.status_msg.emit_sig("Trafo -> line, updated with impedance")
             new_curve = LineSegment(obj=new_line,
                                     dlines=curve.dlines,
                                     coords=curve.coords)
@@ -1070,17 +1085,17 @@ class CircuitInputer(QWidget):
                 blue_pen.setColor(Qt.blue)
                 blue_pen.setWidthF(2.5)
                 line_drawing.setPen(blue_pen)
-                self.Scene.addItem(line_drawing)
+                self.editor.addItem(line_drawing)
             self.add_line(new_curve)
-            self.LayoutManager()
+            self.update_layout()
 
-    def trafoProcessing(self):
+    def submit_trafo(self):
         """
         Updates a trafo with the given parameters if the current element is a trafo
         or converts a line into a trafo with the inputted parameters
         Called by: trafoSubmitPushButton.pressed
         """
-        curve = self.getCurveFromGridPos(self._currElementCoords)
+        curve = self.curve_at(self._curr_element_coord)
         if isinstance(curve.obj, TransmissionLine):
             # Transform line into a trafo
             line = curve.obj
@@ -1088,11 +1103,11 @@ class CircuitInputer(QWidget):
             new_trafo = Transformer(
                 orig=line.orig,
                 dest=line.dest,
-                snom=float(self.SNomTrafoLineEdit.text()) * 1e6,
-                jx0=float(self.XZeroSeqTrafoLineEdit.text()) / 100,
-                jx1=float(self.XPosSeqTrafoLineEdit.text()) / 100,
-                primary=SYMBOL_TO_PY[self.TrafoPrimary.currentText()],
-                secondary=SYMBOL_TO_PY[self.TrafoSecondary.currentText()]
+                snom=float(self.snom_trafo_line_edit.text()) * 1e6,
+                jx0=float(self.x_zero_seq_trafo_line_edit.text()) / 100,
+                jx1=float(self.x_pos_seq_trafo_line_edit.text()) / 100,
+                primary=SYMBOL_TO_PY[self.trafo_primary.currentText()],
+                secondary=SYMBOL_TO_PY[self.trafo_secondary.currentText()]
             )
             new_curve = LineSegment(obj=new_trafo,
                                     dlines=curve.dlines,
@@ -1102,26 +1117,26 @@ class CircuitInputer(QWidget):
                 blue_pen.setColor(Qt.red)
                 blue_pen.setWidthF(2.5)
                 line_drawing.setPen(blue_pen)
-                self.Scene.addItem(line_drawing)
+                self.editor.addItem(line_drawing)
             self.add_trafo(new_curve)
-            self.LayoutManager()
-            self.statusMsg.emit_sig('Line -> trafo')
+            self.update_layout()
+            self.status_msg.emit_sig("Line -> trafo")
         elif isinstance(curve.obj, Transformer):
             # Update parameters of selected trafo
             trafo = curve.obj
-            trafo.snom = float(self.SNomTrafoLineEdit.text()) * 1e6
-            trafo.jx0 = float(self.XZeroSeqTrafoLineEdit.text()) / 100
-            trafo.jx1 = float(self.XPosSeqTrafoLineEdit.text()) / 100
-            trafo.primary = SYMBOL_TO_PY[self.TrafoPrimary.currentText()]
-            trafo.secondary = SYMBOL_TO_PY[self.TrafoSecondary.currentText()]
-            self.LayoutManager()
-            self.statusMsg.emit_sig('Updated trafo parameters')
+            trafo.snom = float(self.snom_trafo_line_edit.text()) * 1e6
+            trafo.jx0 = float(self.x_zero_seq_trafo_line_edit.text()) / 100
+            trafo.jx1 = float(self.x_pos_seq_trafo_line_edit.text()) / 100
+            trafo.primary = SYMBOL_TO_PY[self.trafo_primary.currentText()]
+            trafo.secondary = SYMBOL_TO_PY[self.trafo_secondary.currentText()]
+            self.update_layout()
+            self.status_msg.emit_sig("Updated trafo parameters")
 
     def remove_curve(self, curve=None):
         if curve is None:
-            curve = self.getCurveFromGridPos(self._currElementCoords)
-        for linedrawing in curve.dlines:
-            self.Scene.removeItem(linedrawing)
+            curve = self.curve_at(self._curr_element_coord)
+        for line_drawing in curve.dlines:
+            self.editor.removeItem(line_drawing)
         self.curves.remove(curve)
 
     def remove_trafo(self, curve=None):
@@ -1132,10 +1147,10 @@ class CircuitInputer(QWidget):
             If it is None, current selected trafo in interface will be removed
         """
         if curve is None:
-            curve = self.getCurveFromGridPos(self._currElementCoords)
+            curve = self.curve_at(self._curr_element_coord)
         self.remove_curve(curve)
         self.system.remove_trafo(curve.obj, tuple(curve.coords))
-        self.statusMsg.emit_sig('Removed trafo')
+        self.status_msg.emit_sig("Removed trafo")
 
     def remove_line(self, curve=None):
         """Remove a line (draw and electrical representation)
@@ -1146,12 +1161,12 @@ class CircuitInputer(QWidget):
             If it is None, current selected line in interface will be removed
         """
         if curve is None:
-            curve = self.getCurveFromGridPos(self._currElementCoords)
+            curve = self.curve_at(self._curr_element_coord)
         self.remove_curve(curve)
         self.system.remove_line(curve.obj, tuple(curve.coords))
-        self.statusMsg.emit_sig('Removed line')
+        self.status_msg.emit_sig("Removed line")
 
-    def removeElementsLinked2Bus(self, bus):
+    def remove_elements_linked_to(self, bus):
         """
         Called by: remove_bus
 
@@ -1170,122 +1185,122 @@ class CircuitInputer(QWidget):
         """
         Called by: RemoveBus.pressed
         """
-        coords = self._currElementCoords
-        bus = self.getBusFromGridPos(coords)
+        coord = self._curr_element_coord
+        bus = self.bus_at(coord)
         if bus:
-            self.removeElementsLinked2Bus(bus)
+            self.remove_elements_linked_to(bus)
             n = self.system.id2n(bus.bus_id)
             self.system.remove_bus(n)
-            self.Scene.removeItem(self.Scene.pixmap[coords])
-            self.Scene.pixmap[coords] = 0
-            self.Scene.grid[coords] = 0
+            self.editor.removeItem(self.editor.drawings[coord])
+            self.editor.drawings[coord] = 0
+            self.editor.bus_grid[coord] = 0
 
     def add_gen(self):
         """Adds generation to the bus, make some QLineEdits activated
         Called by: AddGenerationButton.pressed (__init__)
         """
-        bus = self.getBusFromGridPos(self._currElementCoords)
-        self.BusV_Value.setEnabled(True)
-        self.XdLineEdit.setEnabled(True)
+        bus = self.bus_at(self._curr_element_coord)
+        self.bus_v_value.setEnabled(True)
+        self.xd_line_edit.setEnabled(True)
         if bus.bus_id > 0:
-            self.PgInput.setEnabled(True)
-        self.GenGround.setEnabled(True)
-        self.AddGenerationButton.setText('OK')
-        self.statusMsg.emit_sig('Input generation data...')
-        self.AddGenerationButton.disconnect()
-        self.AddGenerationButton.pressed.connect(self.submit_gen)
+            self.pg_input.setEnabled(True)
+        self.gen_ground.setEnabled(True)
+        self.add_generation_button.setText('OK')
+        self.status_msg.emit_sig("Input generation data...")
+        self.add_generation_button.disconnect()
+        self.add_generation_button.pressed.connect(self.submit_gen)
 
     def submit_gen(self):
         """Updates bus parameters with the user input in bus inspector
         Called by: AddedGenerationButton.pressed (add_gen)
         """
-        coords = self._currElementCoords
-        if isinstance(self.Scene.grid[coords], Bus):
-            bus = self.getBusFromGridPos(coords)
-            bus.v = float(self.BusV_Value.text())
-            bus.pg = float(self.PgInput.text()) / 100
-            bus.gen_ground = self.GenGround.isChecked()
-            if self.XdLineEdit.text() == '\u221E':
+        coord = self._curr_element_coord
+        if isinstance(self.editor.bus_grid[coord], Bus):
+            bus = self.bus_at(coord)
+            bus.v = float(self.bus_v_value.text())
+            bus.pg = float(self.pg_input.text()) / 100
+            bus.gen_ground = self.gen_ground.isChecked()
+            if self.xd_line_edit.text() == '\u221E':
                 bus.xd = np.inf
             else:
-                bus.xd = float(self.XdLineEdit.text()) / 100
-            self.BusV_Value.setEnabled(False)
-            self.PgInput.setEnabled(False)
-            self.XdLineEdit.setEnabled(False)
-            self.GenGround.setEnabled(False)
-            self.AddGenerationButton.disconnect()
+                bus.xd = float(self.xd_line_edit.text()) / 100
+            self.bus_v_value.setEnabled(False)
+            self.pg_input.setEnabled(False)
+            self.xd_line_edit.setEnabled(False)
+            self.gen_ground.setEnabled(False)
+            self.add_generation_button.disconnect()
             if bus.bus_id > 0:
-                self.AddGenerationButton.setText('-')
-                self.AddGenerationButton.pressed.connect(self.remove_gen)
+                self.add_generation_button.setText('-')
+                self.add_generation_button.pressed.connect(self.remove_gen)
             else:
-                self.AddGenerationButton.setText('EDIT')
-                self.AddGenerationButton.pressed.connect(self.add_gen)
-            self.statusMsg.emit_sig('Added generation')
+                self.add_generation_button.setText('EDIT')
+                self.add_generation_button.pressed.connect(self.add_gen)
+            self.status_msg.emit_sig("Added generation")
 
     def remove_gen(self):
         """
         Called by: AddGenerationButton.pressed (submit_gen)
         """
-        coords = self._currElementCoords
-        if isinstance(self.Scene.grid[coords], Bus):
-            bus = self.getBusFromGridPos(coords)
+        coord = self._curr_element_coord
+        if isinstance(self.editor.bus_grid[coord], Bus):
+            bus = self.bus_at(coord)
             bus.v = 1
             bus.pg = 0
             bus.xd = np.inf
             bus.gen_ground = False
-            self.updateBusInspector(bus)
-            self.AddGenerationButton.setText('+')
-            self.AddGenerationButton.disconnect()
-            self.AddGenerationButton.pressed.connect(self.add_gen)
-            self.statusMsg.emit_sig('Removed generation')
+            self.bus_menu(bus)
+            self.add_generation_button.setText('+')
+            self.add_generation_button.disconnect()
+            self.add_generation_button.pressed.connect(self.add_gen)
+            self.status_msg.emit_sig("Removed generation")
 
     def add_load(self):
         """
         Called by: AddLoadButton.pressed (__init__)
         """
-        self.PlInput.setEnabled(True)
-        self.QlInput.setEnabled(True)
-        self.LoadGround.setEnabled(True)
-        self.AddLoadButton.setText('OK')
-        self.statusMsg.emit_sig('Input load data...')
-        self.AddLoadButton.disconnect()
-        self.AddLoadButton.pressed.connect(self.submit_load)
+        self.pl_input.setEnabled(True)
+        self.ql_input.setEnabled(True)
+        self.load_ground.setEnabled(True)
+        self.add_load_button.setText("OK")
+        self.status_msg.emit_sig("Input load data...")
+        self.add_load_button.disconnect()
+        self.add_load_button.pressed.connect(self.submit_load)
 
     def submit_load(self):
         """
         Called by: AddLoadButton.pressed (add_load)
         """
-        coords = self._currElementCoords
-        if isinstance(self.Scene.grid[coords], Bus):
-            bus = self.getBusFromGridPos(coords)
-            bus.pl = float(self.PlInput.text()) / 100
-            bus.ql = float(self.QlInput.text()) / 100
-            bus.load_ground = SYMBOL_TO_PY[self.LoadGround.currentText()]
-            self.PlInput.setEnabled(False)
-            self.QlInput.setEnabled(False)
-            self.LoadGround.setEnabled(False)
-            self.AddLoadButton.setText('-')
-            self.AddLoadButton.disconnect()
-            self.AddLoadButton.pressed.connect(self.remove_load)
-            self.statusMsg.emit_sig('Added load')
+        coord = self._curr_element_coord
+        if isinstance(self.editor.bus_grid[coord], Bus):
+            bus = self.bus_at(coord)
+            bus.pl = float(self.pl_input.text()) / 100
+            bus.ql = float(self.ql_input.text()) / 100
+            bus.load_ground = SYMBOL_TO_PY[self.load_ground.currentText()]
+            self.pl_input.setEnabled(False)
+            self.ql_input.setEnabled(False)
+            self.load_ground.setEnabled(False)
+            self.add_load_button.setText('-')
+            self.add_load_button.disconnect()
+            self.add_load_button.pressed.connect(self.remove_load)
+            self.status_msg.emit_sig("Added load")
 
     def remove_load(self):
         """
         Called by: AddLoadButton.pressed (submit_load)
         """
-        coords = self._currElementCoords
-        if isinstance(self.Scene.grid[coords], Bus):
-            bus = self.getBusFromGridPos(coords)
+        coord = self._curr_element_coord
+        if isinstance(self.editor.bus_grid[coord], Bus):
+            bus = self.bus_at(coord)
             bus.pl = 0
             bus.ql = 0
             bus.load_ground = EARTH
-            self.updateBusInspector(bus)
-            self.AddLoadButton.setText('+')
-            self.AddLoadButton.disconnect()
-            self.AddLoadButton.pressed.connect(self.add_load)
-            self.statusMsg.emit_sig('Removed load')
+            self.bus_menu(bus)
+            self.add_load_button.setText('+')
+            self.add_load_button.disconnect()
+            self.add_load_button.pressed.connect(self.add_load)
+            self.status_msg.emit_sig("Removed load")
 
-    def doAfterMouseRelease(self):
+    def update_values(self):
         """
         If line's bool remove is True, the line will be removed.
         The remove may have three causes:
@@ -1295,96 +1310,95 @@ class CircuitInputer(QWidget):
         """
         if self.curves:
             curr_curve = self.curves[-1]
-            curr_curve.remove |= (len(curr_curve.coords) <= 2
-                                  or curr_curve.obj.dest is None
-                                  or curr_curve.obj.dest == curr_curve.obj.orig)
-            if not self._startNewTL and not curr_curve.remove:
-                self.system.add_line(self.curves[-1].obj, tuple(self.curves[-1].coords))
-            self._startNewTL = True
+            curr_curve.remove |= len(curr_curve.coords) <= 2
+            curr_curve.remove |= curr_curve.obj.dest is None
+            curr_curve.remove |= curr_curve.obj.dest == curr_curve.obj.orig
+            if not self._start_line and not curr_curve.remove:
+                self.system.add_line(curr_curve.obj, tuple(curr_curve.coords))
+            self._start_line = True
             if curr_curve.remove:
                 self.remove_curve(curr_curve)
             for curve in self.curves:
                 assert curve.obj.orig is not None
                 assert curve.obj.dest is not None
                 assert curve.obj.dest != curve.obj.orig
+        if self.max_niter > 0:
+            self.system.update(Nmax=self.max_niter)
+        self.update_layout()
 
-        self.system.update(Nmax=self.nmax)
-        self.LayoutManager()
 
-
-class Software(QMainWindow):
+class Window(QMainWindow):
     def __init__(self):
-        super(Software, self).__init__()
+        super(Window, self).__init__()
         # Central widget
-        self.circuit = CircuitInputer()
-        self.circuit.statusMsg.signal.connect(lambda args: self.displayStatusMsg(args))
-        self.setCentralWidget(self.circuit)
+        self.main_widget = MainWidget()
+        self.main_widget.status_msg.signal.connect(self.display_status_msg)
+        self.setCentralWidget(self.main_widget)
 
         self.initUI()
 
     def initUI(self):
-        self.displayStatusMsg('Ready')
-
+        self.display_status_msg("Ready")
         # Actions
-        newSys = QAction('Start new system', self)
-        newSys.setShortcut('Ctrl+N')
-        newSys.triggered.connect(self.startNewSession)
+        new_sys = QAction("Start new system", self)
+        new_sys.setShortcut("Ctrl+N")
+        new_sys.triggered.connect(self.start_new_session)
 
-        saveAct = QAction('Save current session', self)
-        saveAct.setShortcut('Ctrl+S')
-        saveAct.triggered.connect(self.saveSession)
+        save_act = QAction("Save current session", self)
+        save_act.setShortcut("Ctrl+S")
+        save_act.triggered.connect(self.save_session)
 
-        loadAct = QAction('Open session', self)
-        loadAct.setShortcut('Ctrl+O')
-        loadAct.triggered.connect(self.loadSession)
+        load_act = QAction("Open session", self)
+        load_act.setShortcut("Ctrl+O")
+        load_act.triggered.connect(self.load_session)
 
-        createReport = QAction('Generate report', self)
-        createReport.setShortcut('Ctrl+R')
-        createReport.triggered.connect(self.report)
+        create_report = QAction("Generate report", self)
+        create_report.setShortcut("Ctrl+R")
+        create_report.triggered.connect(self.report)
 
-        addLineAct = QAction('Add line type', self)
-        addLineAct.setShortcut('Ctrl+L')
-        addLineAct.triggered.connect(self.addLineType)
+        add_line_act = QAction("Add line type", self)
+        add_line_act.setShortcut("Ctrl+L")
+        add_line_act.triggered.connect(self.add_line_type)
 
-        editLineAct = QAction('Edit line type', self)
-        editLineAct.triggered.connect(self.editLineType)
+        edit_line_act = QAction("Edit line type", self)
+        edit_line_act.triggered.connect(self.edit_line_type)
 
-        configure_simulation = QAction('Configure simulation', self)
-        configure_simulation.setShortcut('Ctrl+X')
-        configure_simulation.triggered.connect(self.configureSimulation)
+        configure_simulation = QAction("Configure simulation", self)
+        configure_simulation.setShortcut("Ctrl+X")
+        configure_simulation.triggered.connect(self.configure_simulation)
 
         # Menu bar
-        menubar = self.menuBar()
+        menu_bar = self.menuBar()
 
-        filemenu = menubar.addMenu('&Session')
-        filemenu.addAction(saveAct)
-        filemenu.addAction(loadAct)
-        filemenu.addAction(createReport)
-        filemenu.addAction(newSys)
+        file_menu = menu_bar.addMenu('&Session')
+        file_menu.addAction(save_act)
+        file_menu.addAction(load_act)
+        file_menu.addAction(create_report)
+        file_menu.addAction(new_sys)
 
-        linemenu = menubar.addMenu('&Lines')
-        linemenu.addAction(addLineAct)
-        linemenu.addAction(editLineAct)
+        line_menu = menu_bar.addMenu('&Lines')
+        line_menu.addAction(add_line_act)
+        line_menu.addAction(edit_line_act)
 
-        settings = menubar.addMenu('S&ettings')
+        settings = menu_bar.addMenu('S&ettings')
         settings.addAction(configure_simulation)
 
-        self.setWindowTitle(NAME)
+        self.setWindowTitle("Electrical Grid Analysis Tool")
         self.setGeometry(50, 50, 1000, 600)
         self.setMinimumWidth(1000)
         self.show()
 
-    def configureSimulation(self):
-        self.circuit.setLayoutHidden(self.circuit.BusLayout, True)
-        self.circuit.setLayoutHidden(self.circuit.LineOrTrafoLayout, True)
-        self.circuit.setLayoutHidden(self.circuit.ControlPanelLayout, False)
-        self.circuit.updateNmaxSlider(self.circuit.nmax)
-        self.circuit.updateNmaxLabel(self.circuit.nmax)
+    def configure_simulation(self):
+        self.main_widget.clear_layout(self.main_widget.bus_layout, True)
+        self.main_widget.clear_layout(self.main_widget.line_or_trafo_layout, True)
+        self.main_widget.clear_layout(self.main_widget.control_panel_layout, False)
+        self.main_widget.update_nmax_slider(self.main_widget.max_niter)
+        self.main_widget.update_nmax_label(self.main_widget.max_niter)
 
-    def displayStatusMsg(self, args):
+    def display_status_msg(self, args):
         self.statusBar().showMessage(args)
 
-    def saveSession(self):
+    def save_session(self):
         sessions_dir = getSessionsDir()
         options = QFileDialog.Options()
         options |= QFileDialog.DontUseNativeDialog
@@ -1395,10 +1409,10 @@ class Software(QMainWindow):
                                                   options=options)
         if filename:
             with open(filename, 'bw') as file:
-                self.storeData(file)
+                self.store_data(file)
                 file.close()
 
-    def loadSession(self):
+    def load_session(self):
         sessions_dir = getSessionsDir()
         options = QFileDialog.Options()
         options |= QFileDialog.DontUseNativeDialog
@@ -1408,103 +1422,106 @@ class Software(QMainWindow):
                                                   filter="All Files (*)",
                                                   options=options)
         if filename:
-            self.startNewSession()
+            self.start_new_session()
             with open(filename, 'br') as file:
-                self.createLocalData(file)
+                self.create_local_data(file)
                 file.close()
-            self.createSchematic(self.circuit.Scene)
+            self.create_schematic(self.main_widget.editor)
 
     def report(self):
         sessions_dir = getSessionsDir()
         options = QFileDialog.Options()
         options |= QFileDialog.DontUseNativeDialog
         if shutil.which("latexmk") is not None:
-            filetype = "PDF Files (*.pdf)"
+            file_type = "PDF Files (*.pdf)"
         else:
-            filetype = "Data Files (*.dat)"
+            file_type = "Data Files (*.dat)"
         filename, _ = QFileDialog.getSaveFileName(parent=self,
                                                   caption="Save Report",
                                                   directory=sessions_dir,
-                                                  filter=filetype,
+                                                  filter=file_type,
                                                   options=options)
         if filename:
-            create_report(self.circuit.system, self.circuit.curves, self.circuit.Scene.grid, filename)
+            create_report(self.main_widget.system, self.main_widget.curves,
+                          self.main_widget.editor.bus_grid, filename)
 
-    def addLineType(self):
-        self.circuit.setLayoutHidden(self.circuit.InputNewLineType, False)
-        self.circuit.setLayoutHidden(self.circuit.BusLayout, True)
-        self.circuit.setLayoutHidden(self.circuit.LineOrTrafoLayout, True)
-        self.displayStatusMsg('Adding new line model')
+    def add_line_type(self):
+        self.main_widget.clear_layout(self.main_widget.new_line_type, False)
+        self.main_widget.clear_layout(self.main_widget.bus_layout, True)
+        self.main_widget.clear_layout(self.main_widget.line_or_trafo_layout, True)
+        self.display_status_msg("Adding new line model")
 
-    def editLineType(self):
-        self.displayStatusMsg("Editing line types is currently not implemented!")
+    def edit_line_type(self):
+        self.display_status_msg("Editing line types is currently not implemented!")
         raise NotImplementedError
 
-    def startNewSession(self):
+    def start_new_session(self):
         self.clear_interface()
         self.reset_system_state_variables()
-        self.circuit.doAfterMouseRelease()
+        self.main_widget.update_values()
 
     def clear_interface(self):
-        to_remove = len(self.circuit.curves)
+        to_remove = len(self.main_widget.curves)
         for i in range(to_remove):
-            self.circuit.remove_curve(self.circuit.curves[0])
-        N = self.circuit.Scene.N
-        for i in range(N):
-            for j in range(N):
-                if isinstance(self.circuit.Scene.grid[i, j], Bus):
-                    self.circuit.Scene.removeItem(self.circuit.Scene.pixmap[i, j])
+            self.main_widget.remove_curve(self.main_widget.curves[0])
+        editor = self.main_widget.editor
+        size = editor.size
+        for i in range(size):
+            for j in range(size):
+                if isinstance(editor.bus_grid[i, j], Bus):
+                    editor.removeItem(editor.drawings[i, j])
 
     def reset_system_state_variables(self):
-        N = self.circuit.Scene.N
-        self.circuit.system = PowerSystem()
-        self.circuit.curves = []
-        self.circuit.Scene.grid = np.zeros((N, N), object)
-        self.circuit.Scene.pixmap = np.zeros((N, N), object)
+        size = self.main_widget.editor.size
+        self.main_widget.system = PowerSystem()
+        self.main_widget.curves = []
+        self.main_widget.editor.bus_grid = np.zeros((size, size), object)
+        self.main_widget.editor.drawings = np.zeros((size, size), object)
 
-    def createLocalData(self, file):
+    def create_local_data(self, file):
         db = pickle.load(file)
-        self.circuit.system = db['SYSTEM']
-        self.circuit.curves = db['CURVES']
-        self.circuit.line_types = db['LINE_TYPES']
-        self.circuit.Scene.grid = db['GRID']
-        for bus in self.circuit.system.buses:
-            assert bus in self.circuit.Scene.grid
-        for curve in self.circuit.curves:
-            assert curve.obj in self.circuit.system.lines or curve.obj in self.circuit.system.trafos
+        self.main_widget.system = db['SYSTEM']
+        self.main_widget.curves = db['CURVES']
+        self.main_widget.line_types = db['LINE_TYPES']
+        self.main_widget.editor.bus_grid = db['GRID']
+        for bus in self.main_widget.system.buses:
+            assert bus in self.main_widget.editor.bus_grid
+        for curve in self.main_widget.curves:
+            assert curve.obj in self.main_widget.system.lines or\
+                   curve.obj in self.main_widget.system.trafos
 
-    def storeData(self, file):
+    def store_data(self, file):
         filtered_curves = []
-        for curve in self.circuit.curves:
+        for curve in self.main_widget.curves:
             filtered_curves.append(LineSegment(obj=curve.obj,
                                                coords=curve.coords,
                                                dlines=[]))
-        db = {'SYSTEM': self.circuit.system,
+        db = {'SYSTEM': self.main_widget.system,
               'CURVES': filtered_curves,
-              'LINE_TYPES': self.circuit.line_types,
-              'GRID': self.circuit.Scene.grid}
+              'LINE_TYPES': self.main_widget.line_types,
+              'GRID': self.main_widget.editor.bus_grid}
         pickle.dump(db, file)
         return db
 
-    def createSchematic(self, scene):
-        squarel = scene.oneSquareSideLength
-        for i in range(scene.N):
-            for j in range(scene.N):
-                if isinstance(scene.grid[i, j], Bus):
-                    point = (squarel / 2 + squarel * j,
-                             squarel / 2 + squarel * i)
-                    drawbus = scene.drawBus(point)
-                    scene.pixmap[i, j] = drawbus
-        for curve in self.circuit.curves:
-            for pairs in interface_coordpairs(curve.coords, squarel):
+    def create_schematic(self, editor):
+        square_length = editor.square_length
+        for i in range(editor.size):
+            for j in range(editor.size):
+                if isinstance(editor.bus_grid[i, j], Bus):
+                    point = (square_length / 2 + square_length * j,
+                             square_length / 2 + square_length * i)
+                    bus = editor.draw_bus(point)
+                    editor.drawings[i, j] = bus
+        for curve in self.main_widget.curves:
+            for pairs in interface_coordpairs(curve.coords, square_length):
                 if isinstance(curve.obj, TransmissionLine):
-                    dline = scene.drawLine(pairs, color='b')
+                    dline = editor.draw_line(pairs, color='b')
                 else:
-                    dline = scene.drawLine(pairs, color='r')
+                    dline = editor.draw_line(pairs, color='r')
                 curve.dlines.append(dline)
 
 
 def main():
     app = QApplication(sys.argv)
-    Software()
+    Window()
     sys.exit(app.exec_())

--- a/elegant/tests/test_interface.py
+++ b/elegant/tests/test_interface.py
@@ -2,37 +2,28 @@ import unittest
 
 from PyQt5.QtWidgets import *
 
-from elegant.interface import Software
+from elegant.interface import Window, STAR, EARTH, DELTA, STAR_SYMBOL, EARTH_SYMBOL, DELTA_SYMBOL
 from ..utils import *
-
-from ..core import STAR, EARTH, DELTA, STAR_SYMBOL, EARTH_SYMBOL, DELTA_SYMBOL
 
 
 class ElegantQt(QWidget):
     def __init__(self, *args, **kwargs):
         super(ElegantQt, self).__init__(*args, *kwargs)
-        self.software = Software()
-        self.software.initUI()
-
-    def insertion_mode(self):
-        self.software.circuit.InsertionModeRadioButton.setChecked(True)
-
-    def real_time_mode(self, slide_value=20):
-        self.software.circuit.RealTimeRadioButton.setChecked(True)
-        self.software.circuit.NmaxSlider.setValue(slide_value)
+        self.window = Window()
+        self.window.initUI()
 
     @staticmethod
     def is_layout_hidden(layout):
-        witems = [layout.itemAt(i).widget() for i in range(layout.count())
-                  if not isinstance(layout.itemAt(i), QLayout)]
-        witems = [witem for witem in witems if witem is not None]
-        for witem in witems:
-            if not witem.isHidden():
+        widgets = [layout.itemAt(i).widget() for i in range(layout.count())
+                   if not isinstance(layout.itemAt(i), QLayout)]
+        widgets = [item for item in widgets if item is not None]
+        for item in widgets:
+            if not item.isHidden():
                 return False
         return True
 
     def get_ditems(self):
-        return self.software.circuit.Scene.items()
+        return self.window.main_widget.editor.items()
 
     @property
     def dbuses_amount(self):
@@ -50,17 +41,17 @@ class ElegantQt(QWidget):
         return len([d for d in ditems if (isinstance(d, QGraphicsLineItem) and d.pen().color().name() == '#ff0000')])
 
     def reset_session(self):
-        self.software.startNewSession()
+        self.window.start_new_session()
 
     def load_test_session(self):
         filename = getTestDbFile()
         with open(filename, 'br') as file:
-            self.software.createLocalData(file)
+            self.window.create_local_data(file)
             file.close()
-        self.software.createSchematic(self.software.circuit.Scene)
+        self.window.create_schematic(self.window.main_widget.editor)
 
     def update_bus_inspector(self, bus):
-        self.software.circuit.updateBusInspector(bus)
+        self.window.main_widget.bus_menu(bus)
 
 
 app = QApplication(sys.argv)
@@ -69,44 +60,33 @@ app = QApplication(sys.argv)
 class InterfaceTests(unittest.TestCase):
     def setUp(self):
         self.elegantqt = ElegantQt()
-        self.circuit = self.elegantqt.software.circuit
+        self.main_widget = self.elegantqt.window.main_widget
 
     def test_initial_ui(self):
-        self.assertTrue(self.elegantqt.is_layout_hidden(self.circuit.BusLayout), 'BusLayout is not hidden')
-        self.assertTrue(self.elegantqt.is_layout_hidden(self.circuit.LineOrTrafoLayout), 'LineOrTrafoLayout is not hidden')
-        self.assertTrue(self.elegantqt.is_layout_hidden(self.circuit.InputNewLineType), 'InputNewLineType is not hidden')
-        self.assertTrue(self.elegantqt.is_layout_hidden(self.circuit.ControlPanelLayout),
-                        'ControlPanelLayout is not hidden')
-
-    def test_insertion_mode(self):
-        self.elegantqt.insertion_mode()
-        self.assertFalse(self.circuit.RealTimeRadioButton.isChecked())
-        self.assertEqual(self.circuit.NmaxLabel.text(), 'Nmax: --')
-        self.assertEqual(self.circuit.op_mode, 1)
-
-    def test_real_time_mode(self):
-        self.elegantqt.real_time_mode(20)
-        self.assertFalse(self.circuit.InsertionModeRadioButton.isChecked())
-        self.assertEqual(self.circuit.NmaxLabel.text(), 'Nmax: {}'.format(self.circuit.nmax).zfill(2))
-        self.elegantqt.real_time_mode(5)
-        self.assertFalse(self.circuit.InsertionModeRadioButton.isChecked())
-        self.assertEqual(self.circuit.NmaxLabel.text(), 'Nmax: {}'.format(self.circuit.nmax).zfill(2))
+        self.assertTrue(self.elegantqt.is_layout_hidden(self.main_widget.bus_layout),
+                        "BusLayout is not hidden")
+        self.assertTrue(self.elegantqt.is_layout_hidden(self.main_widget.line_or_trafo_layout),
+                        "LineOrTrafoLayout is not hidden")
+        self.assertTrue(self.elegantqt.is_layout_hidden(self.main_widget.new_line_type),
+                        "InputNewLineType is not hidden")
+        self.assertTrue(self.elegantqt.is_layout_hidden(self.main_widget.control_panel_layout),
+                        "ControlPanelLayout is not hidden")
 
     def test_bus_drawing(self):
-        self.elegantqt.software.circuit.Scene.drawBus((0, 0))
+        self.elegantqt.window.main_widget.editor.draw_bus((0, 0))
         self.assertEqual(1, self.elegantqt.dbuses_amount)
-        p = self.elegantqt.software.circuit.Scene.drawBus((1, 0))
+        p = self.elegantqt.window.main_widget.editor.draw_bus((1, 0))
         self.assertEqual(type(p), QGraphicsEllipseItem)
         self.assertEqual(0, self.elegantqt.dlines_amount)
         self.assertEqual(0, self.elegantqt.dtrafos_amount)
 
     def test_bus_clearing(self):
-        b = self.elegantqt.software.circuit.Scene.drawBus((0, 0))
+        b = self.elegantqt.window.main_widget.editor.draw_bus((0, 0))
         self.assertTrue(type(b) == QGraphicsEllipseItem)
         self.assertEqual(1, self.elegantqt.dbuses_amount)
-        pixmap = self.elegantqt.software.circuit.Scene.pixmap
-        pixmap[0, 0] = b
-        self.elegantqt.software.circuit.Scene.removeItem(pixmap[0, 0])
+        drawings = self.elegantqt.window.main_widget.editor.drawings
+        drawings[0, 0] = b
+        self.elegantqt.window.main_widget.editor.removeItem(drawings[0, 0])
         self.assertEqual(0, self.elegantqt.dbuses_amount)
 
     def test_load_session(self):
@@ -121,37 +101,37 @@ class InterfaceTests(unittest.TestCase):
 
     def test_branches_amount(self):
         self.elegantqt.load_test_session()
-        self.assertEqual(17, len(self.elegantqt.software.circuit.curves))
+        self.assertEqual(17, len(self.elegantqt.window.main_widget.curves))
 
     def test_bus_type_change(self):
-        self.elegantqt.software.circuit.add_bus()
-        bus = self.circuit.system.buses[0]
+        self.elegantqt.window.main_widget.add_bus()
+        bus = self.main_widget.system.buses[0]
         self.assertEqual(EARTH, bus.load_ground)
         self.elegantqt.update_bus_inspector(bus)
 
         # Default case
-        self.assertEqual(EARTH_SYMBOL, self.elegantqt.software.circuit.LoadGround.currentText())
+        self.assertEqual(EARTH_SYMBOL, self.elegantqt.window.main_widget.load_ground.currentText())
 
         bus.load_ground = DELTA
         # Interface does not change (pl = 0)
         self.elegantqt.update_bus_inspector(bus)
-        self.assertEqual(EARTH_SYMBOL, self.elegantqt.software.circuit.LoadGround.currentText())
+        self.assertEqual(EARTH_SYMBOL, self.elegantqt.window.main_widget.load_ground.currentText())
 
         bus.pl = 10
 
         # Interface changes (pl > 0)
         bus.load_ground = STAR
         self.elegantqt.update_bus_inspector(bus)
-        self.assertEqual(STAR_SYMBOL, self.elegantqt.software.circuit.LoadGround.currentText())
+        self.assertEqual(STAR_SYMBOL, self.elegantqt.window.main_widget.load_ground.currentText())
 
         bus.load_ground = DELTA
         self.elegantqt.update_bus_inspector(bus)
-        self.assertEqual(DELTA_SYMBOL, self.elegantqt.software.circuit.LoadGround.currentText())
+        self.assertEqual(DELTA_SYMBOL, self.elegantqt.window.main_widget.load_ground.currentText())
 
         bus.pl = 0
         # Default case (because pl = 0)
         self.elegantqt.update_bus_inspector(bus)
-        self.assertEqual(EARTH_SYMBOL, self.elegantqt.software.circuit.LoadGround.currentText())
+        self.assertEqual(EARTH_SYMBOL, self.elegantqt.window.main_widget.load_ground.currentText())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I changed camelCase function names and attributes to lowercase_with_underscores as well as some relevant changes to improve readability:

- `View` to `ScrollView`
- `SchemeInputer` to `Editor`
- `quantizedInterface` to `coord_grid`
- `CircuitInputer` to `MainWidget`
- `setLayoutHidden` to `clear_layout`
- `getBusFromGridPos` to `bus_at` (and `getCurveFromGridPos` to `curve_at`)
- `LayoutManager` to `update_layout`
- `doAfterMouseRelease` to `update_values`
- `Software` to `Window`

The corresponding tests are also updated.