### PR TITLE
Separating GUI functions from `MainWidget.__init__`

### DIFF
--- a/elegant/interface.py
+++ b/elegant/interface.py
@@ -19,6 +19,7 @@ DELTA_SYMBOL = "\u0394"
 PY_TO_SYMBOL = {STAR: STAR_SYMBOL, EARTH: EARTH_SYMBOL, DELTA: DELTA_SYMBOL}
 SYMBOL_TO_PY = {STAR_SYMBOL: STAR, EARTH_SYMBOL: EARTH, DELTA_SYMBOL: DELTA}
 
+
 class Block:
     def __init__(self, start=False, end=True):
         self.start = start
@@ -79,81 +80,65 @@ class ScrollView(QGraphicsView):
         self.verticalScrollBar().valueChanged.connect(self.erase)
 
     def erase(self):
-        if self.scene().selectorHistory.dsquare_obj is not None:
-            self.scene().removeItem(self.scene().selectorHistory.dsquare_obj)
-            self.scene().selectorHistory.dsquare_obj = None
+        if self.scene().cursor is not None:
+            self.scene().removeItem(self.scene().cursor)
+            self.scene().cursor = None
 
 
 class Editor(QGraphicsScene):
     def __init__(self, size=20, length=50):
         super(Editor, self).__init__()
         self.size = size
-        self.View = ScrollView(self)
+        self.view = ScrollView(self)
 
         # System state variables
         self.drawings = np.zeros((self.size, self.size), object)
         self.bus_grid = np.zeros((self.size, self.size), object)
         self.square_length = length
+        self.circle_radius = length / 2
         self.move_history = HistoryData()
         self.block = Block()
         self.selectorHistory = HistoryData()
-        self.selectorHistory.__setattr__('dsquare_obj', None)
+        self.cursor = None
 
         self.pointer_signal = GenericSignal()
         self.method_signal = GenericSignal()
         self.data_signal = GenericSignal()
 
         # Visible portion of Scene to View
-        self.circle_radius = length / 2
-        self.setSceneRect(0,
-                          0,
+        self.setSceneRect(0, 0,
                           self.square_length * self.size,
                           self.square_length * self.size)
-        self.coord_grid = self.get_coord_grid()
+        self.coord_grid = np.array([[[int(length * (i + .5)),
+                                      int(length * (j + .5))]
+                                     for i in range(size)]
+                                    for j in range(size)])
         self.draw_grid()
         self.setSceneRect(self.square_length * -2,
                           self.square_length * -2,
                           self.square_length * (self.size + 4),
                           self.square_length * (self.size + 4))
 
-    @staticmethod
-    def distance(interface_point, point):
+    def draw_grid(self):
+        """Display the quantized interface guidelines"""
+        width, height = self.width(), self.height()
+        boundaries = self.coord_grid[0, :, 0] - self.square_length / 2
+        pen = QPen()
+        pen.setColor(Qt.lightGray)
+        pen.setStyle(Qt.DashDotDotLine)
+        for boundary in boundaries:
+            # Horizontal lines
+            self.addLine(0.0, boundary, width, boundary, pen)
+            # Vertical lines
+            self.addLine(boundary, 0.0, boundary, height, pen)
+        self.addLine(0.0, height, width, height, pen)
+        self.addLine(width, 0.0, width, height, pen)
+
+    def draw_line(self, coord_1, coord_2, color='b'):
         """
         Parameters
         ----------
-        interface_point: center of bump box from interface points
-        point: clicked point by user
-
-        Returns
-        -------
-        : distance between point and interface_point
-        """
-        return np.hypot(interface_point[0] - point.x(), interface_point[1] - point.y())
-
-    def ij_from_QPoint(self, central_point):
-        """
-        Parameters
-        ----------
-        central_point: coordinates of quantized point from interface
-
-        Returns
-        -------
-        : index codes for point, given its quantized coordinates
-        """
-        i = int((central_point.y() - self.square_length / 2) / self.square_length)
-        j = int((central_point.x() - self.square_length / 2) / self.square_length)
-        return i, j
-
-    def QPoint_from_ij(self, i, j):
-        for central_point in self.coord_grid.flatten():
-            if (i, j) == self.ij_from_QPoint(central_point):
-                return central_point
-
-    def draw_line(self, coordinates, color='b'):
-        """
-        Parameters
-        ----------
-        coordinates: coordinates that guide line drawing
+        coord_1, coord_2: line end points
         color:  'b' = blue pen (line)
                 'r' = red pen (trafo)
 
@@ -167,14 +152,14 @@ class Editor(QGraphicsScene):
             pen.setColor(Qt.blue)
         elif color == 'r':
             pen.setColor(Qt.red)
-        line = self.addLine(coordinates[0, 0], coordinates[0, 1], coordinates[1, 0], coordinates[1, 1], pen)
+        line = self.addLine(coord_1[0], coord_1[1], coord_2[0], coord_2[1], pen)
         return line
 
-    def draw_square(self, coordinates):
+    def draw_square(self, coord):
         """
         Parameters
         ----------
-        coordinates: coordinates that guide square drawing
+        coord: square top-left corner
 
         Returns
         -------
@@ -182,23 +167,40 @@ class Editor(QGraphicsScene):
         """
         pen = QPen(Qt.yellow)
         brush = QBrush(Qt.yellow, Qt.Dense7Pattern)
-        x, y = coordinates
-        rect = self.addRect(x, y, self.square_length, self.square_length, pen, brush)
+        x, y = coord
+        rect = self.addRect(x, y,
+                            self.square_length, self.square_length,
+                            pen, brush)
         return rect
 
-    def draw_bus(self, coordinates):
-        c = np.array(coordinates) - self.square_length / 4
+    def draw_bus(self, coord):
+        x, y = np.array(coord) - self.circle_radius / 2
         pen = QPen(Qt.black)
         brush = QBrush(Qt.SolidPattern)
-        ellipse = self.addEllipse(*c, self.square_length / 2, self.square_length / 2, pen, brush)
-        return ellipse
+        circle = self.addEllipse(x, y,
+                                 self.circle_radius, self.circle_radius,
+                                 pen, brush)
+        return circle
 
-    def get_central_point(self, event):
-        coordinates = event.scenePos().x(), event.scenePos().y()
-        for central_point in self.coord_grid.flatten():
-            if self.distance(coordinates, central_point) <= self.circle_radius:
-                i, j = self.ij_from_QPoint(central_point)
-                return central_point, i, j
+    def get_central_point(self, coord):
+        legs = self.coord_grid - coord
+        good = (np.hypot(legs[:, :, 0], legs[:, :, 1]) < self.circle_radius)
+        i, j = good.nonzero()
+        if i.size > 0 and j.size > 0:
+            return i[0], j[0]
+        return None
+
+    def redraw_cursor(self, x, y):
+        if self.cursor is not None:
+            self.removeItem(self.cursor)
+        self.selectorHistory.set_current(x - self.square_length / 2,
+                                          y - self.square_length / 2)
+        self.cursor = self.draw_square(self.selectorHistory.current)
+
+    def is_drawing_blocked(self):
+        return self.block.start or \
+               self.block.end or \
+               not self.move_history.allows_drawing
 
     def mouseReleaseEvent(self, event):
         self.move_history.reset()
@@ -207,87 +209,47 @@ class Editor(QGraphicsScene):
         self.method_signal.emit_sig(3)
 
     def mouseDoubleClickEvent(self, event):
-        if self.get_central_point(event):
-            central_point, i, j = self.get_central_point(event)
-            circle = self.draw_bus((central_point.x(), central_point.y()))
+        coord = [event.scenePos().x(), event.scenePos().y()]
+        if self.get_central_point(coord) is not None:
+            i, j = self.get_central_point(coord)
+            x, y = self.coord_grid[i, j]
+            circle = self.draw_bus((x, y))
             self.drawings[i, j] = circle
             self.pointer_signal.emit_sig((i, j))
             self.method_signal.emit_sig(0)
 
-    def redraw_cursor(self, x, y):
-        if self.selectorHistory.dsquare_obj is not None:
-            self.removeItem(self.selectorHistory.dsquare_obj)
-        self.selectorHistory.set_current(x - self.square_length / 2,
-                                         y - self.square_length / 2)
-        self.selectorHistory.dsquare_obj = self.draw_square(self.selectorHistory.current)
-
     def mousePressEvent(self, event):
-        if self.get_central_point(event):
-            central_point, i, j = self.get_central_point(event)
-            x, y = central_point.x(), central_point.y()
+        coord = [event.scenePos().x(), event.scenePos().y()]
+        if self.get_central_point(coord) is not None:
+            i, j = self.get_central_point(coord)
+            x, y = self.coord_grid[i, j]
             self.redraw_cursor(x, y)
             self.pointer_signal.emit_sig((i, j))
             self.method_signal.emit_sig(4)
             self.method_signal.emit_sig(2)
 
-    @property
-    def is_drawing_blocked(self):
-        return self.block.start or self.block.end
-
-    def draw_line_suite(self, i, j):
-        coordinates = np.atleast_2d(np.array([self.move_history.last, self.move_history.current]))
-        line = self.draw_line(coordinates, color='b')
-        self.move_history.reset()
-        self.pointer_signal.emit_sig((i, j))
-        self.data_signal.emit_sig(line)
-        self.method_signal.emit_sig(1)
-
     def mouseMoveEvent(self, event):
-        if self.get_central_point(event):
-            central_point, i, j = self.get_central_point(event)
-            if central_point is not None:
-                x, y = central_point.x(), central_point.y()
-                self.redraw_cursor(x, y)
-                if self.move_history.is_empty:
-                    self.move_history.set_last(x, y)
-                    if isinstance(self.bus_grid[i, j], Bus):
-                        self.block.start = False
-                if self.move_history.is_last_different_from(x, y):
-                    self.move_history.set_current(x, y)
-                if self.move_history.allows_drawing and not self.is_drawing_blocked:
-                    self.draw_line_suite(i, j)
-                    if isinstance(self.bus_grid[i, j], Bus):
-                        self.block.end = True
-
-    def get_coord_grid(self):
-        """
-        Returns
-        -------
-        coord_grid: numpy array that holds PyQt QPoint objects with quantized interface coordinates
-        """
-        coord_grid = np.zeros((self.size, self.size), tuple)
-        width, height = self.width(), self.height()
-        for i in range(self.size):
-            for j in range(self.size):
-                coord_grid[i, j] = QPoint(int(width / (2 * self.size) + i * width / self.size),
-                                          int(height / (2 * self.size) + j * height / self.size))
-        return coord_grid
-
-    def draw_grid(self):
-        """Display the quantized interface guidelines"""
-        width, height = self.width(), self.height()
-        spacing_x, spacing_y = width / self.size, height / self.size
-        quantized_x, quantized_y = np.arange(0, width, spacing_x), np.arange(0, height, spacing_y)
-        pen = QPen()
-        pen.setColor(Qt.lightGray)
-        pen.setStyle(Qt.DashDotDotLine)
-        for k in range(self.size):
-            # Horizontal lines
-            self.addLine(0.0, quantized_y[k], width, quantized_y[k], pen)
-            # Vertical lines
-            self.addLine(quantized_x[k], 0.0, quantized_x[k], height, pen)
-        self.addLine(0.0, self.height(), width, self.height(), pen)
-        self.addLine(self.width(), 0.0, self.width(), height, pen)
+        coord = [event.scenePos().x(), event.scenePos().y()]
+        if self.get_central_point(coord) is not None:
+            i, j = self.get_central_point(coord)
+            x, y = self.coord_grid[i, j]
+            self.redraw_cursor(x, y)
+            if self.move_history.is_empty:
+                self.move_history.set_last(x, y)
+                if isinstance(self.bus_grid[i, j], Bus):
+                    self.block.start = False
+            if self.move_history.is_last_different_from(x, y):
+                self.move_history.set_current(x, y)
+            if not self.is_drawing_blocked():
+                coord_1 = self.move_history.last
+                coord_2 = self.move_history.current
+                line = self.draw_line(coord_1, coord_2, color='b')
+                self.move_history.reset()
+                self.pointer_signal.emit_sig((i, j))
+                self.data_signal.emit_sig(line)
+                self.method_signal.emit_sig(1)
+                if isinstance(self.bus_grid[i, j], Bus):
+                    self.block.end = True
 
 
 class MainWidget(QWidget):
@@ -303,10 +265,10 @@ class MainWidget(QWidget):
         self.editor = Editor()
 
         # self.View = QGraphicsView(self.Scene)
-        self.view = self.editor.View
-        self.editor_layout = QHBoxLayout()  # Layout for SchemeInput
+        self.view = self.editor.view
+        self.editor_layout = QHBoxLayout()  # Layout for editor
         self.editor_layout.addWidget(self.view)
-        self._curr_element_coord = None  # Coordinates to current object being manipuled
+        self._curr_element_coord = None  # Coordinates to current object
         self._start_line = True
         self._line_origin = None
         self._temp = None
@@ -321,308 +283,14 @@ class MainWidget(QWidget):
         self.editor.method_signal.signal.connect(self.methods_trigger)
 
         # Inspectors
-        self.inspector_layout = QVBoxLayout()
-
-        # Layout for general bus case
-        self.bus_layout = QVBoxLayout()
-
-        # Bus title
-        self.bus_title = QLabel("Bus title")
-        self.bus_title.setAlignment(Qt.AlignCenter)
-        self.bus_title.setMinimumWidth(self.sidebar_width)
-        self.bus_title.setMaximumWidth(self.sidebar_width)
-
-        # Bus voltage
-        self.bus_v_value = QLineEdit("0.0")
-        self.bus_v_value.setEnabled(False)
-        self.bus_v_value.setValidator(QDoubleValidator(bottom=0., top=100.))
-
-        # Bus angle
-        self.bus_angle_value = QLineEdit("0.0")
-        self.bus_angle_value.setEnabled(False)
-
-        # FormLayout to hold bus data
-        self.bus_data_form_layout = QFormLayout()
-
-        # Adding bus voltage and bus angle to bus data FormLayout
-        self.bus_data_form_layout.addRow("|V| (pu)", self.bus_v_value)
-        self.bus_data_form_layout.addRow("\u03b4 (\u00B0)", self.bus_angle_value)
-
-        # Label with 'Generation'
-        self.add_generation_label = QLabel("Generation")
-        self.add_generation_label.setAlignment(Qt.AlignCenter)
-
-        # Button to add generation
-        self.add_generation_button = QPushButton('+')
-        self.add_generation_button.pressed.connect(self.add_gen)  # Bind button to make input editable
-
-        # FormLayout to add generation section
-        self.add_generation_form_layout = QFormLayout()
-        self.add_load_form_layout = QFormLayout()
-
-        # Line edit to Xd bus
-        self.xd_line_edit = QLineEdit("\u221E")
-        self.xd_line_edit.setValidator(QDoubleValidator())
-        self.xd_line_edit.setEnabled(False)
-
-        # Line edit to input bus Pg
-        self.pg_input = QLineEdit("0.0")
-        self.pg_input.setValidator(QDoubleValidator(bottom=0.))
-        self.pg_input.setEnabled(False)
-
-        # Line edit to input bus Qg
-        self.qg_input = QLineEdit("0.0")
-        self.qg_input.setValidator(QDoubleValidator())
-        self.qg_input.setEnabled(False)
-
-        # Check box for generation ground
-        self.gen_ground = QCheckBox("\u23DA")
-        self.gen_ground.setEnabled(False)
-
-        # Adding Pg, Qg to add generation FormLayout
-        self.add_generation_form_layout.addRow("x (%pu)", self.xd_line_edit)
-        self.add_generation_form_layout.addRow("P<sub>G</sub> (MW)", self.pg_input)
-        self.add_generation_form_layout.addRow("Q<sub>G</sub> (Mvar)", self.qg_input)
-        self.add_generation_form_layout.addRow("Y", self.gen_ground)
-
-        # Label with 'Load'
-        self.add_load_label = QLabel("Load")
-        self.add_load_label.setAlignment(Qt.AlignCenter)
-
-        # PushButton that binds to three different methods
-        self.add_load_button = QPushButton('+')
-        self.add_load_button.pressed.connect(self.add_load)
-
-        # LineEdit with Ql, Pl
-        self.ql_input = QLineEdit("0.0")
-        self.ql_input.setValidator(QDoubleValidator())
-        self.pl_input = QLineEdit("0.0")
-        self.pl_input.setValidator(QDoubleValidator())
-        self.pl_input.setEnabled(False)
-        self.ql_input.setEnabled(False)
-
-        # Check box to load ground
-        # self.LoadGround = QCheckBox("\u23DA")
-        self.load_ground = QComboBox()
-        self.load_ground.addItem("Y")
-        self.load_ground.addItem("Y\u23DA")
-        self.load_ground.addItem("\u0394")
-        self.load_ground.setEnabled(False)
-
-        # Adding Pl and Ql to add load FormLayout
-        self.add_load_form_layout.addRow("P<sub>L</sub> (MW)", self.pl_input)
-        self.add_load_form_layout.addRow("Q<sub>L</sub> (Mvar)", self.ql_input)
-        self.add_load_form_layout.addRow("Y", self.load_ground)
-
-        self.remove_bus_button = QPushButton('Remove bus')
-        self.remove_bus_button.pressed.connect(self.remove_bus)
-
-        self.bus_layout.addWidget(self.bus_title)
-        self.bus_layout.addLayout(self.bus_data_form_layout)
-        self.bus_layout.addWidget(self.add_generation_label)
-        self.bus_layout.addWidget(self.add_generation_button)
-        self.bus_layout.addLayout(self.add_generation_form_layout)
-        self.bus_layout.addWidget(self.add_load_label)
-        self.bus_layout.addWidget(self.add_load_button)
-        self.bus_layout.addLayout(self.add_load_form_layout)
-        self.bus_layout.addWidget(self.remove_bus_button)
-
-        # Layout for input new type of line
-        self.new_line_type = QVBoxLayout()
-        self.new_line_type_form_layout = QFormLayout()
-
-        self.model_name = QLineEdit()
-        self.model_name.setValidator(QRegExpValidator(QRegExp("[A-Za-z]*")))
-        self.rho_line_edit = QLineEdit()
-        self.rho_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.r_line_edit = QLineEdit()
-        self.r_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.d12_line_edit = QLineEdit()
-        self.d12_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.d23_line_edit = QLineEdit()
-        self.d23_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.d31_line_edit = QLineEdit()
-        self.d31_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.d_line_edit = QLineEdit()
-        self.d_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
-        self.m_line_edit = QLineEdit()
-        self.m_line_edit.setValidator(QIntValidator(bottom=1, top=4))
-        self.imax_line_edit = QLineEdit()
-        self.imax_line_edit.setValidator(QDoubleValidator(bottom=0.))
-
-        self.new_line_type_form_layout.addRow("Name", self.model_name)
-        self.new_line_type_form_layout.addRow("\u03C1 (n\u03A9m)", self.rho_line_edit)
-        self.new_line_type_form_layout.addRow("r (mm)", self.r_line_edit)
-        self.new_line_type_form_layout.addRow("d12 (m)", self.d12_line_edit)
-        self.new_line_type_form_layout.addRow("d23 (m)", self.d23_line_edit)
-        self.new_line_type_form_layout.addRow("d31 (m)", self.d31_line_edit)
-        self.new_line_type_form_layout.addRow("d (m)", self.d_line_edit)
-        self.new_line_type_form_layout.addRow("m", self.m_line_edit)
-        self.new_line_type_form_layout.addRow("Imax (A)", self.imax_line_edit)
-
-        self.new_line_type.addStretch()
-        self.new_line_type.addLayout(self.new_line_type_form_layout)
-        self.submit_new_line_type_push_button = QPushButton("Submit")
-        self.submit_new_line_type_push_button.setMinimumWidth(self.sidebar_width)
-        self.submit_new_line_type_push_button.setMaximumWidth(self.sidebar_width)
-        self.submit_new_line_type_push_button.pressed.connect(self.add_new_line_model)
-        self.new_line_type.addWidget(self.submit_new_line_type_push_button)
-        self.new_line_type.addStretch()
-
-        # Layout for simulation control panel
-        self.control_panel_layout = QVBoxLayout()
-
-        self.nmax_hbox = QHBoxLayout()
-        self.nmax_slider = QSlider()
-        self.nmax_slider.setMinimum(0)
-        self.nmax_slider.setMaximum(50)
-        self.nmax_slider.setOrientation(Qt.Vertical)
-        self.nmax_label = QLabel("Nmax: {:02d}".format(self.max_niter))
-        self.nmax_slider.valueChanged.connect(self.set_nmax)
-        self.nmax_hbox.addWidget(self.nmax_label)
-        self.nmax_hbox.addWidget(self.nmax_slider)
-
-        self.control_panel_layout.addStretch()
-        self.control_panel_layout.addLayout(self.nmax_hbox)
-        self.control_panel_layout.addStretch()
-
-        # General Layout for TL case
-        self.line_or_trafo_layout = QVBoxLayout()
-
-        self.choose_line = QRadioButton("TL")
-        self.choose_trafo = QRadioButton("TRAFO")
-        self.choose_line.toggled.connect(self.toggle_line_trafo)
-        self.choose_trafo.toggled.connect(self.toggle_line_trafo)
-
-        self.choose_line_or_trafo = QHBoxLayout()
-        self.choose_line_or_trafo.addWidget(QLabel("TL/TRAFO:"))
-        self.choose_line_or_trafo.addWidget(self.choose_line)
-        self.choose_line_or_trafo.addWidget(self.choose_trafo)
-
-        self.chosen_line_form_layout = QFormLayout()
-
-        self.choose_line_model = QComboBox()
-        self.choose_line_model.addItem("No model")
-
-        self.ell_line_edit = QLineEdit()
-        self.ell_line_edit.setValidator(QDoubleValidator(bottom=0.))
-
-        self.vbase_line_edit = QLineEdit()
-        self.vbase_line_edit.setValidator(QDoubleValidator(bottom=0.))
-
-        self.tl_r_line_edit = QLineEdit()
-        self.tl_r_line_edit.setValidator(QDoubleValidator(bottom=0.))
-
-        self.tl_x_line_edit = QLineEdit()
-        self.tl_x_line_edit.setValidator(QDoubleValidator(bottom=0.))
-
-        self.tl_b_line_edit = QLineEdit()
-        self.tl_b_line_edit.setValidator(QDoubleValidator(bottom=0.))
-
-        self.tl_submit_by_impedance_button = QPushButton("Submit by impedance")
-        self.tl_submit_by_impedance_button.setMinimumWidth(self.sidebar_width)
-        self.tl_submit_by_impedance_button.setMaximumWidth(self.sidebar_width)
-        self.tl_submit_by_impedance_button.pressed.connect(lambda: self.submit_line('impedance'))
-
-        self.tl_submit_by_model_button = QPushButton("Submit by model")
-        self.tl_submit_by_model_button.pressed.connect(lambda: self.submit_line('parameters'))
-        self.tl_submit_by_model_button.setMinimumWidth(self.sidebar_width)
-        self.tl_submit_by_model_button.setMaximumWidth(self.sidebar_width)
-
-        self.chosen_line_form_layout.addRow("Model", self.choose_line_model)
-        self.chosen_line_form_layout.addRow("\u2113 (km)", self.ell_line_edit)
-        self.chosen_line_form_layout.addRow("Vbase (kV)", self.vbase_line_edit)
-        self.chosen_line_form_layout.addRow("R (%pu)", self.tl_r_line_edit)
-        self.chosen_line_form_layout.addRow("X<sub>L</sub> (%pu)", self.tl_x_line_edit)
-        self.chosen_line_form_layout.addRow("B<sub>C</sub> (%pu)", self.tl_b_line_edit)
-
-        self.remove_tl_push_button = QPushButton('Remove TL')
-        self.remove_tl_push_button.setMinimumWidth(self.sidebar_width)
-        self.remove_tl_push_button.setMaximumWidth(self.sidebar_width)
-        self.remove_tl_push_button.pressed.connect(self.remove_line)
-        """" 
-        # Reason of direct button bind to self.LayoutManager: 
-        #     The layout should disappear only when a line or trafo is excluded.
-        #     The conversion trafo <-> line calls the method remove_selected_(line/trafo)
-        """
-        self.remove_tl_push_button.pressed.connect(self.update_layout)
-
-        self.chosen_trafo_form_layout = QFormLayout()
-        self.snom_trafo_line_edit = QLineEdit()
-        self.snom_trafo_line_edit.setValidator(QDoubleValidator(bottom=0.))
-        self.x_zero_seq_trafo_line_edit = QLineEdit()
-        self.x_zero_seq_trafo_line_edit.setValidator(QDoubleValidator(bottom=0.))
-        self.x_pos_seq_trafo_line_edit = QLineEdit()
-        self.x_pos_seq_trafo_line_edit.setValidator(QDoubleValidator(bottom=0.))
-
-        self.trafo_primary = QComboBox()
-        self.trafo_primary.addItem('Y')
-        self.trafo_primary.addItem('Y\u23DA')
-        self.trafo_primary.addItem('\u0394')
-        self.trafo_secondary = QComboBox()
-        self.trafo_secondary.addItem('Y')
-        self.trafo_secondary.addItem('Y\u23DA')
-        self.trafo_secondary.addItem('\u0394')
-
-        self.trafo_submit_push_button = QPushButton('Submit trafo')
-        self.trafo_submit_push_button.pressed.connect(self.submit_trafo)
-        self.trafo_submit_push_button.setMinimumWidth(self.sidebar_width)
-        self.trafo_submit_push_button.setMaximumWidth(self.sidebar_width)
-
-        self.remove_trafo_push_button = QPushButton('Remove trafo')
-        self.remove_trafo_push_button.pressed.connect(self.remove_trafo)
-        """" 
-        # Reason of direct button bind to self.LayoutManager: 
-        #     The layout should disappear only when a line or trafo is excluded.
-        #     The conversion trafo <-> line calls the method remove_selected_(line/trafo)
-        """
-        self.remove_trafo_push_button.pressed.connect(self.update_layout)
-        self.remove_trafo_push_button.setMinimumWidth(self.sidebar_width)
-        self.remove_trafo_push_button.setMaximumWidth(self.sidebar_width)
-
-        self.chosen_trafo_form_layout.addRow("Snom (MVA)", self.snom_trafo_line_edit)
-        self.chosen_trafo_form_layout.addRow("x+ (%pu)", self.x_pos_seq_trafo_line_edit)
-        self.chosen_trafo_form_layout.addRow("x0 (%pu)", self.x_zero_seq_trafo_line_edit)
-        self.chosen_trafo_form_layout.addRow("Prim.", self.trafo_primary)
-        self.chosen_trafo_form_layout.addRow("Sec.", self.trafo_secondary)
-
-        self.line_or_trafo_layout.addLayout(self.choose_line_or_trafo)
-        self.line_or_trafo_layout.addLayout(self.chosen_line_form_layout)
-        self.line_or_trafo_layout.addLayout(self.chosen_trafo_form_layout)
-
-        # Submit and remove buttons for line
-        self.line_or_trafo_layout.addWidget(self.tl_submit_by_model_button)
-        self.line_or_trafo_layout.addWidget(self.tl_submit_by_impedance_button)
-        self.line_or_trafo_layout.addWidget(self.remove_tl_push_button)
-
-        # Buttons submit and remove button for trafo
-        self.line_or_trafo_layout.addWidget(self.trafo_submit_push_button)
-        self.line_or_trafo_layout.addWidget(self.remove_trafo_push_button)
-
-        # Layout that holds bus inspector and Stretches
-        self.sidebar_layout = QVBoxLayout()
-        self.inspector_layout.addStretch()
-        self.inspector_layout.addLayout(self.bus_layout)
-        self.inspector_layout.addLayout(self.line_or_trafo_layout)
-        self.inspector_layout.addStretch()
-        self.sidebar_layout.addLayout(self.inspector_layout)
-
-        # Toplayout
+        self.left_sidebar_layout = QHBoxLayout()
+        self.right_sidebar_layout = QHBoxLayout()
         self.top_layout = QHBoxLayout()
-        self.spacer = QSpacerItem(self.sidebar_width, 0, QSizePolicy.Fixed, QSizePolicy.Fixed)
-        self.top_layout.addItem(self.spacer)
-        self.top_layout.addLayout(self.sidebar_layout)
+        self.top_layout.addLayout(self.left_sidebar_layout)
         self.top_layout.addLayout(self.editor_layout)
-        self.top_layout.addLayout(self.new_line_type)
-        self.top_layout.addLayout(self.control_panel_layout)
+        self.top_layout.addLayout(self.right_sidebar_layout)
         self.setLayout(self.top_layout)
-
-        # All layouts hidden at first moment
-        self.clear_layout(self.bus_layout, True)
-        self.clear_layout(self.line_or_trafo_layout, True)
-        self.clear_layout(self.new_line_type, True)
-        self.clear_layout(self.control_panel_layout, True)
-        self.show_spacer()
+        self.no_menu()
 
     def methods_trigger(self, args):
         """Trigger methods defined in __calls"""
@@ -632,15 +300,10 @@ class MainWidget(QWidget):
         """Define coordinates pointing to current selected object in interface"""
         self._curr_element_coord = args
 
-    def hide_spacer(self):
-        self.spacer.changeSize(0, 0)
-
-    def show_spacer(self):
-        self.spacer.changeSize(self.sidebar_width, 0)
-
     def set_temp(self, args):
-        """This method stores the first line in line element drawing during line inputting.
-        Its existence is justified by the first square limitation in MouseMoveEvent
+        """This method stores the first line in line element drawing during line
+        inputting. Its existence is justified by the first square limitation in
+        MouseMoveEvent
         """
         self._temp = args
 
@@ -648,28 +311,22 @@ class MainWidget(QWidget):
         if self._start_line:
             self._line_origin = self._curr_element_coord
 
-    def clear_layout(self, layout, visible):
+    def clear_layout(self, layout):
         """Hide completely any layout containing widgets or/and other layouts"""
         widgets = list(layout.itemAt(i).widget() for i in range(layout.count())
                        if not isinstance(layout.itemAt(i), QLayout))
         widgets = list(filter(lambda x: x is not None, widgets))
         for w in widgets:
-            w.setHidden(visible)
+            w.setHidden(True)
         layouts = list(layout.itemAt(i).layout() for i in range(layout.count())
                        if isinstance(layout.itemAt(i), QLayout))
         for child_layout in layouts:
-            self.clear_layout(child_layout, visible)
+            self.clear_layout(child_layout)
+            layout.removeItem(child_layout)
 
-    def update_nmax_label(self, nmax):
-        self.nmax_label.setText("Nmax: {:02d}".format(nmax))
-
-    def update_nmax_slider(self, nmax):
-        self.nmax_slider.setEnabled(True)
-        self.nmax_slider.setValue(nmax)
-
-    def set_nmax(self, nmax):
+    def set_nmax(self, nmax, nmax_label):
         self.max_niter = nmax
-        self.update_nmax_label(self.max_niter)
+        nmax_label.setText("Nmax: {:02d}".format(self.max_niter))
 
     def bus_at(self, coord):
         """Returns a Bus object that occupies grid in `coord` position"""
@@ -717,224 +374,546 @@ class MainWidget(QWidget):
         self._start_line = False
         self.status_msg.emit_sig("Adding line...")
 
-    def find_line_model_from_object(self, line):
+    def find_line_model(self, line):
         """Return the name of parameters set of a existent line or
-        return None if the line has been set by impedance and admittance
+        return "No model" if the line has been set by impedance and admittance
         """
         for line_name, line_model in self.line_types.items():
             if line_model.param == line.param:
                 return line_name
         return "No model"
 
-    def find_line_model_from_text(self):
-        """Find parameters set based on current selected line or trafo inspector combo box
-        If the line was set with impedance/admittance, return 'None'
-        """
-        set_name = self.choose_line_model.currentText()
-        for line_name, line_model in self.line_types.items():
-            if set_name == line_name:
-                return line_model
-        return None
-
-    def add_new_line_model(self):
+    def add_new_line_model(self, name, new_param):
         """Add a new type of line, if given parameters has passed in all the tests
         Called by: SubmitNewLineTypePushButton.pressed"""
-        name = self.model_name.text()
-
-        def float_or_nan(s):
-            return np.nan if s == '' else float(s)
-        new_param = dict(
-            r=float_or_nan(self.r_line_edit.text()) / 1e3,
-            d12=float_or_nan(self.d12_line_edit.text()),
-            d23=float_or_nan(self.d23_line_edit.text()),
-            d31=float_or_nan(self.d31_line_edit.text()),
-            d=float_or_nan(self.d_line_edit.text()),
-            rho=float_or_nan(self.rho_line_edit.text()) / 1e9,
-            m=float_or_nan(self.m_line_edit.text()),
-            imax=float_or_nan(self.imax_line_edit.text())
-        )
         line = TransmissionLine(orig=None, dest=None)
         line.__dict__.update(new_param)
         if name in self.line_types.keys():
-            self.status_msg.emit_sig('Duplicated name. Insert another valid name')
+            self.status_msg.emit_sig("Duplicated name. Insert another valid name")
             return
         if any(np.isnan(list(new_param.values()))):
-            self.status_msg.emit_sig('Undefined parameter. Fill all parameters')
+            self.status_msg.emit_sig("Undefined parameter. Fill all parameters")
             return
         if any(map(lambda x: line.param == x.param, self.line_types.values())):
-            self.status_msg.emit_sig('A similar model was identified. The model has not been stored')
+            self.status_msg.emit_sig("A similar model was identified. The model has not been stored")
             return
         self.line_types[name] = line
-        self.status_msg.emit_sig('The model has been stored')
+        self.status_msg.emit_sig("The model has been stored")
 
-    @staticmethod
-    def submit_line_by_model(line, param_values, ell, vbase):
+    def submit_line_by_model(self, line_model, ell, vbase):
         """Update a line with parameters
 
         Parameters
         ----------
-        line: TL object to be updated
-        param_values: TL object with data to update line
+        line_model: TL object with data to update line
         ell: line length (m)
         vbase: voltage base (V)
         """
-        line.Z, line.Y = None, None
-        line.__dict__.update(param_values.param)
-        line.vbase = vbase
-        line.ell = ell
+        curve = self.curve_at(self._curr_element_coord)
+        if isinstance(curve.obj, TransmissionLine):
+            line = curve.obj
+            line.Z, line.Y = None, None
+            line.__dict__.update(line_model.param)
+            line.vbase = vbase
+            line.ell = ell
+            self.status_msg.emit_sig("Updated line with model")
+        elif isinstance(curve.obj, Transformer):
+            trafo = curve.obj
+            self.remove_trafo(curve)
+            new_line = TransmissionLine(orig=trafo.orig, dest=trafo.dest)
+            new_line.Z, new_line.Y = None, None
+            new_line.__dict__.update(line_model.param)
+            new_line.vbase = vbase
+            new_line.ell = ell
+            self.status_msg.emit_sig("Trafo -> line, updated with model")
+            new_curve = LineSegment(obj=new_line,
+                                    dlines=curve.dlines,
+                                    coords=curve.coords)
+            for line_drawing in new_curve.dlines:
+                blue_pen = QPen()
+                blue_pen.setColor(Qt.blue)
+                blue_pen.setWidthF(2.5)
+                line_drawing.setPen(blue_pen)
+                self.editor.addItem(line_drawing)
+                self.add_line(new_curve)
 
-    @staticmethod
-    def submit_line_by_impedance(line, Z, Y, ell, vbase):
+    def submit_line_by_impedance(self, tl_r, tl_x, tl_b, ell, vbase):
         """Update a line with impedance/admittance
 
         Parameters
         ----------
-        line: TL object to be updated
-        Z: impedance (ohm)
-        Y: admittance (mho)
+        tl_r: resistance (ohm)
+        tl_x: reactance (ohm)
+        tl_b: susceptance (mho)
         ell: line length (m)
         vbase: voltage base (V)
         """
-        zbase = vbase ** 2 / 1e8
-        line.Z, line.Y = Z * zbase, Y / zbase
-        line.ell = ell
-        line.vbase = vbase
-        line.m = 0
+        curve = self.curve_at(self._curr_element_coord)
+        if isinstance(curve.obj, TransmissionLine):
+            line = curve.obj
+            tl_z = tl_r + 1j * tl_x
+            tl_y = 1j * tl_b
+            zbase = vbase ** 2 / 1e8
+            line.Z, line.Y = tl_z * zbase, tl_y / zbase
+            line.ell = ell
+            line.vbase = vbase
+            line.m = 0
+            self.status_msg.emit_sig("Updated line with impedance")
+        elif isinstance(curve.obj, Transformer):
+            trafo = curve.obj
+            self.remove_trafo(curve)
+            new_line = TransmissionLine(orig=trafo.orig, dest=trafo.dest)
+            tl_z = tl_r + 1j * tl_x
+            tl_y = 1j * tl_b
+            zbase = vbase ** 2 / 1e8
+            new_line.Z, new_line.Y = tl_z * zbase, tl_y / zbase
+            new_line.ell = ell
+            new_line.vbase = vbase
+            new_line.m = 0
+            self.status_msg.emit_sig("Trafo -> line, updated with impedance")
+            new_curve = LineSegment(obj=new_line,
+                                    dlines=curve.dlines,
+                                    coords=curve.coords)
+            for line_drawing in new_curve.dlines:
+                blue_pen = QPen()
+                blue_pen.setColor(Qt.blue)
+                blue_pen.setWidthF(2.5)
+                line_drawing.setPen(blue_pen)
+                self.editor.addItem(line_drawing)
+            self.add_line(new_curve)
 
-    def update_line_model_options(self):
-        """Add the name of a new parameter set to QComboBox choose model,
-           if the Combo has not the model yet
-        -----------------------------------------------------------------
-        """
-        for line_name in self.line_types.keys():
-            if self.choose_line_model.isVisible() and self.choose_line_model.findText(line_name) < 0:
-                self.choose_line_model.addItem(line_name)
-
-    def toggle_line_trafo(self):
+    def toggle_line_trafo(self, check):
         """Show line or trafo options in adding line/trafo section"""
-        if not self.choose_line.isHidden() and not self.choose_trafo.isHidden():
-            if self.choose_line.isChecked():
-                # Line
-                self.clear_layout(self.chosen_line_form_layout, False)
-                self.clear_layout(self.chosen_trafo_form_layout, True)
-                self.remove_tl_push_button.setHidden(False)
-                self.tl_submit_by_impedance_button.setHidden(False)
-                self.tl_submit_by_model_button.setHidden(False)
-                self.trafo_submit_push_button.setHidden(True)
-                self.remove_trafo_push_button.setHidden(True)
-            elif self.choose_trafo.isChecked():
-                # Trafo
-                self.clear_layout(self.chosen_line_form_layout, True)
-                self.clear_layout(self.chosen_trafo_form_layout, False)
-                self.remove_tl_push_button.setHidden(True)
-                self.tl_submit_by_impedance_button.setHidden(True)
-                self.tl_submit_by_model_button.setHidden(True)
-                self.trafo_submit_push_button.setHidden(False)
-                self.remove_trafo_push_button.setHidden(False)
+        if check:
+            self.line_menu()
+        else:
+            self.trafo_menu()
+
+    def no_menu(self):
+        no_layout = QHBoxLayout()
+        no_layout.addSpacing(self.sidebar_width)
+        self.clear_layout(self.left_sidebar_layout)
+        self.clear_layout(self.right_sidebar_layout)
+        self.left_sidebar_layout.addLayout(no_layout)
 
     def trafo_menu(self):
-        """Update trafo inspector
-        Calls
-        -----
-        LayoutManager, trafoProcessing
-        """
         curve = self.curve_at(self._curr_element_coord)
-        if curve is not None:
-            trafo = curve.obj
-            self.snom_trafo_line_edit.setText('{:.3g}'.format(trafo.snom / 1e6))
-            self.x_zero_seq_trafo_line_edit.setText('{:.3g}'.format(trafo.jx0 * 100))
-            self.x_pos_seq_trafo_line_edit.setText('{:.3g}'.format(trafo.jx1 * 100))
-            self.trafo_primary.setCurrentText(PY_TO_SYMBOL[trafo.primary])
-            self.trafo_secondary.setCurrentText(PY_TO_SYMBOL[trafo.secondary])
+        if isinstance(curve.obj, TransmissionLine):
+            trafo = Transformer(orig=None, dest=None)
         else:
-            self.snom_trafo_line_edit.setText('100')
-            self.x_zero_seq_trafo_line_edit.setText('0.0')
-            self.x_pos_seq_trafo_line_edit.setText('0.0')
-            self.trafo_primary.setCurrentText(PY_TO_SYMBOL[1])
-            self.trafo_secondary.setCurrentText(PY_TO_SYMBOL[1])
+            trafo = curve.obj
+        trafo_layout = QVBoxLayout()
+
+        choose_line = QRadioButton('TL')
+        choose_trafo = QRadioButton('TRAFO')
+        choose_trafo.setChecked(True)
+        choose_line.toggled.connect(self.toggle_line_trafo)
+
+        choose_line_or_trafo_box = QGroupBox("")
+        choose_line_or_trafo = QHBoxLayout()
+        choose_line_or_trafo.addWidget(choose_line)
+        choose_line_or_trafo.addWidget(choose_trafo)
+        choose_line_or_trafo_box.setLayout(choose_line_or_trafo)
+
+        trafo_form_layout = QFormLayout()
+        s_nom_trafo_line_edit = QLineEdit("{:.3g}".format(trafo.snom / 1e6))
+        s_nom_trafo_line_edit.setValidator(QDoubleValidator(bottom=0.))
+        x_zero_seq_trafo_line_edit = QLineEdit("{:.3g}".format(trafo.jx0 * 100))
+        x_zero_seq_trafo_line_edit.setValidator(QDoubleValidator(bottom=0.))
+        x_pos_seq_trafo_line_edit = QLineEdit("{:.3g}".format(trafo.jx1 * 100))
+        x_pos_seq_trafo_line_edit.setValidator(QDoubleValidator(bottom=0.))
+
+        trafo_primary = QComboBox()
+        trafo_primary.addItem('Y')
+        trafo_primary.addItem('Y\u23DA')
+        trafo_primary.addItem('\u0394')
+        trafo_secondary = QComboBox()
+        trafo_secondary.addItem('Y')
+        trafo_secondary.addItem('Y\u23DA')
+        trafo_secondary.addItem('\u0394')
+        trafo_primary.setCurrentText(PY_TO_SYMBOL[trafo.primary])
+        trafo_secondary.setCurrentText(PY_TO_SYMBOL[trafo.secondary])
+
+        def submit_trafo():
+            snom = float(s_nom_trafo_line_edit.text()) * 1e6
+            x0 = float(x_zero_seq_trafo_line_edit.text()) / 100
+            x1 = float(x_pos_seq_trafo_line_edit.text()) / 100
+            primary = SYMBOL_TO_PY[trafo_primary.currentText()]
+            secondary = SYMBOL_TO_PY[trafo_secondary.currentText()]
+            self.submit_trafo(snom, x0, x1, primary, secondary)
+
+        trafo_submit_push_button = QPushButton("Submit trafo")
+        trafo_submit_push_button.pressed.connect(submit_trafo)
+        trafo_submit_push_button.setMinimumWidth(self.sidebar_width)
+        trafo_submit_push_button.setMaximumWidth(self.sidebar_width)
+
+        remove_trafo_push_button = QPushButton("Remove trafo")
+        remove_trafo_push_button.pressed.connect(self.remove_trafo)
+        """
+        Reason of direct button bind to self.update_layout: 
+        The layout should disappear only when a line or trafo is excluded.
+        The conversion trafo <-> line calls the method remove_selected_(line/trafo)
+        """
+        remove_trafo_push_button.pressed.connect(self.update_layout)
+        remove_trafo_push_button.setMinimumWidth(self.sidebar_width)
+        remove_trafo_push_button.setMaximumWidth(self.sidebar_width)
+
+        trafo_form_layout.addRow("Snom (MVA)", s_nom_trafo_line_edit)
+        trafo_form_layout.addRow("x+ (%pu)", x_pos_seq_trafo_line_edit)
+        trafo_form_layout.addRow("x0 (%pu)", x_zero_seq_trafo_line_edit)
+        trafo_form_layout.addRow("Prim.", trafo_primary)
+        trafo_form_layout.addRow("Sec.", trafo_secondary)
+
+        trafo_layout.addStretch()
+        trafo_layout.addWidget(choose_line_or_trafo_box)
+        trafo_layout.addLayout(trafo_form_layout)
+
+        # Buttons submit and remove button for trafo
+        trafo_layout.addWidget(trafo_submit_push_button)
+        trafo_layout.addWidget(remove_trafo_push_button)
+        trafo_layout.addStretch()
+
+        self.clear_layout(self.left_sidebar_layout)
+        self.left_sidebar_layout.addLayout(trafo_layout)
 
     def line_menu(self):
-        """Updates the line inspector
-        Calls
-        -----
-        LayoutManager, lineProcessing
-        """
         curve = self.curve_at(self._curr_element_coord)
-        line = curve.obj
-        line_model = self.find_line_model_from_object(line)
-        self.ell_line_edit.setText('{:.03g}'.format(line.ell / 1e3))
-        self.vbase_line_edit.setText('{:.03g}'.format(line.vbase / 1e3))
-        self.tl_r_line_edit.setText('{number.real:.04f}'.format(number=line.Zpu * 100))
-        self.tl_x_line_edit.setText('{number.imag:.04f}'.format(number=line.Zpu * 100))
-        self.tl_b_line_edit.setText('{number.imag:.04f}'.format(number=line.Ypu * 100))
-        self.choose_line_model.setCurrentText(line_model)
-
-    def bus_menu(self, bus):
-        """Updates the bus inspector with bus data if bus exists or
-        shows that there's no bus (only after bus exclusion)
-        Called by: LayoutManager, remove_gen, remove_load
-
-        Parameters
-        ----------
-        bus: Bus object whose data will be displayed
-        """
-        to_be_disabled = [self.pg_input,
-                          self.pl_input,
-                          self.ql_input,
-                          self.bus_v_value,
-                          self.xd_line_edit,
-                          self.load_ground,
-                          self.gen_ground]
-        for item in to_be_disabled:
-            item.setDisabled(True)
-        if bus:
-            if bus.bus_id == 0:
-                self.bus_title.setText("Slack")
-            else:
-                self.bus_title.setText("Bus {}".format(bus.bus_id + 1))
-            if bus.pl > 0 or bus.ql > 0:
-                self.add_load_button.setText('-')
-                self.add_load_button.disconnect()
-                self.add_load_button.pressed.connect(self.remove_load)
-                self.load_ground.setCurrentText(PY_TO_SYMBOL[bus.load_ground])
-            else:
-                self.add_load_button.setText('+')
-                self.add_load_button.disconnect()
-                self.add_load_button.pressed.connect(self.add_load)
-                self.load_ground.setCurrentText(PY_TO_SYMBOL[EARTH])
-            if (bus.pg > 0 or bus.qg > 0) and bus.bus_id > 0:
-                self.add_generation_button.setText('-')
-                self.add_generation_button.disconnect()
-                self.add_generation_button.pressed.connect(self.remove_gen)
-            elif bus.bus_id == 0:
-                self.add_generation_button.setText('EDIT')
-                self.add_generation_button.disconnect()
-                self.add_generation_button.pressed.connect(self.add_gen)
-            else:
-                self.add_generation_button.setText('+')
-                self.add_generation_button.disconnect()
-                self.add_generation_button.pressed.connect(self.add_gen)
-            self.bus_v_value.setText("{:.3g}".format(bus.v))
-            self.bus_angle_value.setText("{:.3g}".format(bus.delta * 180 / np.pi))
-            self.qg_input.setText("{:.4g}".format(bus.qg * 100))
-            self.pg_input.setText("{:.4g}".format(bus.pg * 100))
-            self.ql_input.setText("{:.4g}".format(bus.ql * 100))
-            self.pl_input.setText("{:.4g}".format(bus.pl * 100))
-            self.xd_line_edit.setText("{:.3g}".format(bus.xd))
-            self.gen_ground.setChecked(bus.gen_ground)
-
-        if bus.xd == np.inf:
-            self.xd_line_edit.setText("\u221E")
+        if isinstance(curve.obj, Transformer):
+            line = self.line_types['Default']
         else:
-            self.xd_line_edit.setText("{:.3g}".format(bus.xd * 100))
+            line = curve.obj
+        line_model = self.find_line_model(line)
+
+        line_layout = QVBoxLayout()
+
+        choose_line = QRadioButton('TL')
+        choose_line.setChecked(True)
+        choose_trafo = QRadioButton('TRAFO')
+        choose_line.toggled.connect(self.toggle_line_trafo)
+
+        choose_line_or_trafo_box = QGroupBox("")
+        choose_line_or_trafo = QHBoxLayout()
+        choose_line_or_trafo.addWidget(choose_line)
+        choose_line_or_trafo.addWidget(choose_trafo)
+        choose_line_or_trafo_box.setLayout(choose_line_or_trafo)
+
+        line_form_layout = QFormLayout()
+
+        choose_line_model = QComboBox()
+        choose_line_model.addItem("No model")
+        for model in self.line_types:
+            choose_line_model.addItem(model)
+        choose_line_model.setCurrentText(line_model)
+
+        ell_line_edit = QLineEdit("{:.03g}".format(line.ell / 1e3))
+        ell_line_edit.setValidator(QDoubleValidator(bottom=0.))
+        vbase_line_edit = QLineEdit("{:.03g}".format(line.vbase / 1e3))
+        vbase_line_edit.setValidator(QDoubleValidator(bottom=0.))
+        tl_r_line_edit = QLineEdit("{:.04f}".format(line.Zpu.real * 100))
+        tl_r_line_edit.setValidator(QDoubleValidator(bottom=0.))
+        tl_x_line_edit = QLineEdit("{:.04f}".format(line.Zpu.imag * 100))
+        tl_x_line_edit.setValidator(QDoubleValidator(bottom=0.))
+        tl_b_line_edit = QLineEdit("{:.04f}".format(line.Ypu.imag * 100))
+        tl_b_line_edit.setValidator(QDoubleValidator(bottom=0.))
+
+        def submit_line_by_impedance():
+            tl_r = float(tl_r_line_edit.text()) / 100
+            tl_x = float(tl_x_line_edit.text()) / 100
+            tl_b = float(tl_b_line_edit.text()) / 100
+            ell = float(ell_line_edit.text()) * 1e3
+            vbase = float(vbase_line_edit.text()) * 1e3
+            self.submit_line_by_impedance(tl_r, tl_x, tl_b, ell, vbase)
+        tl_submit_by_impedance_button = QPushButton("Submit by impedance")
+        tl_submit_by_impedance_button.setMinimumWidth(self.sidebar_width)
+        tl_submit_by_impedance_button.setMaximumWidth(self.sidebar_width)
+        tl_submit_by_impedance_button.pressed.connect(submit_line_by_impedance)
+
+        def submit_line_by_model():
+            line_model = self.line_types[choose_line_model.currentText()]
+            ell = float(ell_line_edit.text()) * 1e3
+            vbase = float(vbase_line_edit.text()) * 1e3
+            self.submit_line_by_model(line_model, ell, vbase)
+        tl_submit_by_model_button = QPushButton("Submit by model")
+        tl_submit_by_model_button.pressed.connect(submit_line_by_model)
+        tl_submit_by_model_button.setMinimumWidth(self.sidebar_width)
+        tl_submit_by_model_button.setMaximumWidth(self.sidebar_width)
+
+        line_form_layout.addRow("Model", choose_line_model)
+        line_form_layout.addRow("\u2113 (km)", ell_line_edit)
+        line_form_layout.addRow("Vbase (kV)", vbase_line_edit)
+        line_form_layout.addRow("R (%pu)", tl_r_line_edit)
+        line_form_layout.addRow("X<sub>L</sub> (%pu)", tl_x_line_edit)
+        line_form_layout.addRow("B<sub>C</sub> (%pu)", tl_b_line_edit)
+
+        remove_tl_push_button = QPushButton("Remove TL")
+        remove_tl_push_button.setMinimumWidth(self.sidebar_width)
+        remove_tl_push_button.setMaximumWidth(self.sidebar_width)
+        remove_tl_push_button.pressed.connect(self.remove_line)
+        """" 
+        # Reason of direct button bind to self.LayoutManager: 
+        #     The layout should disappear only when a line or trafo is excluded.
+        #     The conversion trafo <-> line calls the method remove_selected_(line/trafo)
+        """
+        remove_tl_push_button.pressed.connect(self.update_layout)
+
+        line_layout.addStretch()
+        line_layout.addWidget(choose_line_or_trafo_box)
+        line_layout.addLayout(line_form_layout)
+
+        # Submit and remove buttons for line
+        line_layout.addWidget(tl_submit_by_model_button)
+        line_layout.addWidget(tl_submit_by_impedance_button)
+        line_layout.addWidget(remove_tl_push_button)
+        line_layout.addStretch()
+
+        self.clear_layout(self.left_sidebar_layout)
+        self.left_sidebar_layout.addLayout(line_layout)
+
+    def new_line_model_menu(self):
+        # Layout for input new type of line
+        new_line_type = QVBoxLayout()
+        new_line_type_form_layout = QFormLayout()
+
+        model_name = QLineEdit()
+        model_name.setValidator(QRegExpValidator(QRegExp("[A-Za-z]*")))
+        rho_line_edit = QLineEdit()
+        rho_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        r_line_edit = QLineEdit()
+        r_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        d12_line_edit = QLineEdit()
+        d12_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        d23_line_edit = QLineEdit()
+        d23_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        d31_line_edit = QLineEdit()
+        d31_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        d_line_edit = QLineEdit()
+        d_line_edit.setValidator(QDoubleValidator(bottom=0., top=100.))
+        m_line_edit = QLineEdit()
+        m_line_edit.setValidator(QIntValidator(bottom=1, top=4))
+        imax_line_edit = QLineEdit()
+        imax_line_edit.setValidator(QDoubleValidator(bottom=0.))
+
+        new_line_type_form_layout.addRow("Name", model_name)
+        new_line_type_form_layout.addRow("\u03C1 (n\u03A9m)", rho_line_edit)
+        new_line_type_form_layout.addRow("r (mm)", r_line_edit)
+        new_line_type_form_layout.addRow("d12 (m)", d12_line_edit)
+        new_line_type_form_layout.addRow("d23 (m)", d23_line_edit)
+        new_line_type_form_layout.addRow("d31 (m)", d31_line_edit)
+        new_line_type_form_layout.addRow("d (m)", d_line_edit)
+        new_line_type_form_layout.addRow("m", m_line_edit)
+        new_line_type_form_layout.addRow("Imax (A)", imax_line_edit)
+
+        new_line_type.addStretch()
+        new_line_type.addLayout(new_line_type_form_layout)
+
+        def add_new_line_model():
+            name = model_name.text()
+
+            def float_or_nan(s):
+                return np.nan if s == '' else float(s)
+            new_param = dict(
+                r=float_or_nan(r_line_edit.text()) / 1e3,
+                d12=float_or_nan(d12_line_edit.text()),
+                d23=float_or_nan(d23_line_edit.text()),
+                d31=float_or_nan(d31_line_edit.text()),
+                d=float_or_nan(d_line_edit.text()),
+                rho=float_or_nan(rho_line_edit.text()) / 1e9,
+                m=float_or_nan(m_line_edit.text()),
+                imax=float_or_nan(imax_line_edit.text())
+            )
+            self.add_new_line_model(name, new_param)
+
+        submit_new_line_type_push_button = QPushButton("Submit")
+        submit_new_line_type_push_button.setMinimumWidth(self.sidebar_width)
+        submit_new_line_type_push_button.setMaximumWidth(self.sidebar_width)
+        submit_new_line_type_push_button.pressed.connect(add_new_line_model)
+        new_line_type.addWidget(submit_new_line_type_push_button)
+        new_line_type.addStretch()
+
+        self.clear_layout(self.right_sidebar_layout)
+        self.right_sidebar_layout.addLayout(new_line_type)
+
+    def control_panel_menu(self):
+        # Layout for simulation control panel
+        control_panel_layout = QVBoxLayout()
+
+        nmax_hbox = QHBoxLayout()
+        nmax_slider = QSlider()
+        nmax_slider.setMinimum(0)
+        nmax_slider.setMaximum(50)
+        nmax_slider.setValue(self.max_niter)
+        nmax_slider.setOrientation(Qt.Vertical)
+        nmax_label = QLabel("Nmax: {:02d}".format(self.max_niter))
+        nmax_slider.valueChanged.connect(lambda val: self.set_nmax(val,
+                                                                   nmax_label))
+        nmax_hbox.addWidget(nmax_label)
+        nmax_hbox.addWidget(nmax_slider)
+
+        control_panel_layout.addStretch()
+        control_panel_layout.addLayout(nmax_hbox)
+        control_panel_layout.addStretch()
+
+        self.clear_layout(self.right_sidebar_layout)
+        self.right_sidebar_layout.addLayout(control_panel_layout)
+
+    def bus_menu(self, bus, edit_gen=False, edit_load=False):
+        # Layout for general bus case
+        bus_layout = QVBoxLayout()
+        is_slack = (bus.bus_id == 0)
+        has_load = (bus.pl != 0 or bus.ql != 0)
+        has_gen = (bus.pg > 0 or bus.qg != 0)
+        # Bus title
+        if is_slack:
+            bus_title = QLabel("Slack")
+        else:
+            bus_title = QLabel("Bus {}".format(bus.bus_id + 1))
+        bus_title.setAlignment(Qt.AlignCenter)
+        bus_title.setMinimumWidth(self.sidebar_width)
+        bus_title.setMaximumWidth(self.sidebar_width)
+
+        # Bus voltage
+        bus_v_value = QLineEdit("{:.3g}".format(bus.v))
+        bus_v_value.setValidator(QDoubleValidator(bottom=0., top=100.))
+        if not edit_gen:
+            bus_v_value.setEnabled(False)
+        # Bus angle
+        bus_angle_value = QLineEdit("{:.3g}".format(bus.delta * 180 / np.pi))
+        bus_angle_value.setEnabled(False)
+
+        # FormLayout to hold bus data
+        bus_data_form_layout = QFormLayout()
+        # Adding bus voltage and bus angle to bus data FormLayout
+        bus_data_form_layout.addRow("|V| (pu)", bus_v_value)
+        bus_data_form_layout.addRow("\u03b4 (\u00B0)", bus_angle_value)
+
+        # Label with 'Generation'
+        add_generation_label = QLabel("Generation")
+        add_generation_label.setAlignment(Qt.AlignCenter)
+
+        # Line edit to Xd bus
+        if bus.xd == np.inf:
+            xd_line_edit = QLineEdit("\u221E")
+        else:
+            xd_line_edit = QLineEdit("{:.3g}".format(bus.xd * 100))
+        xd_line_edit.setValidator(QDoubleValidator())
+        if not edit_gen:
+            xd_line_edit.setEnabled(False)
+        # Line edit to input bus Pg
+        pg_input = QLineEdit("{:.4g}".format(bus.pg * 100))
+        pg_input.setValidator(QDoubleValidator(bottom=0.))
+        if is_slack or not edit_gen:
+            pg_input.setEnabled(False)
+        # Line edit to input bus Qg
+        qg_input = QLineEdit("{:.4g}".format(bus.qg * 100))
+        qg_input.setValidator(QDoubleValidator())
+        qg_input.setEnabled(False)
+        # Check box for generation ground
+        gen_ground = QCheckBox("\u23DA")
+        gen_ground.setChecked(bus.gen_ground)
+        if not edit_gen:
+            gen_ground.setEnabled(False)
+
+        # Button to add generation
+        if edit_gen:
+            def submit_gen():
+                bus_v = float(bus_v_value.text())
+                pg = float(pg_input.text()) / 100
+                if xd_line_edit.text() == "\u221E":
+                    xd = np.inf
+                else:
+                    xd = float(xd_line_edit.text()) / 100
+                self.submit_gen(bus_v, pg, gen_ground.isChecked(), xd)
+
+            add_generation_button = QPushButton('OK')
+            add_generation_button.pressed.connect(submit_gen)
+        elif is_slack:
+            add_generation_button = QPushButton('EDIT')
+            add_generation_button.pressed.connect(self.add_gen)
+        elif has_gen:
+            add_generation_button = QPushButton('-')
+            add_generation_button.pressed.connect(self.remove_gen)
+        else:
+            add_generation_button = QPushButton('+')
+            add_generation_button.pressed.connect(self.add_gen)
+
+        # FormLayout to add generation section
+        add_generation_form_layout = QFormLayout()
+        # Adding Pg, Qg to add generation FormLayout
+        add_generation_form_layout.addRow("x (%pu)", xd_line_edit)
+        add_generation_form_layout.addRow("P<sub>G</sub> (MW)", pg_input)
+        add_generation_form_layout.addRow("Q<sub>G</sub> (Mvar)", qg_input)
+        add_generation_form_layout.addRow("Y", gen_ground)
+
+        # Label with 'Load'
+        add_load_label = QLabel("Load")
+        add_load_label.setAlignment(Qt.AlignCenter)
+
+        # LineEdit with Ql, Pl
+        ql_input = QLineEdit("{:.4g}".format(bus.ql * 100))
+        ql_input.setValidator(QDoubleValidator())
+        pl_input = QLineEdit("{:.4g}".format(bus.pl * 100))
+        pl_input.setValidator(QDoubleValidator())
+        if not edit_load:
+            pl_input.setEnabled(False)
+            ql_input.setEnabled(False)
+        # Check box to load ground
+        load_ground = QComboBox()
+        load_ground.addItem("Y")
+        load_ground.addItem("Y\u23DA")
+        load_ground.addItem("\u0394")
+        load_ground.setCurrentText(PY_TO_SYMBOL[bus.load_ground])
+        if not edit_load:
+            load_ground.setEnabled(False)
+
+        # PushButton that binds to three different methods
+        if edit_load:
+            def submit_load():
+                pl = float(pl_input.text()) / 100
+                ql = float(ql_input.text()) / 100
+                lg = SYMBOL_TO_PY[load_ground.currentText()]
+                self.submit_load(pl, ql, lg)
+
+            add_load_button = QPushButton('OK')
+            add_load_button.pressed.connect(submit_load)
+        elif has_load:
+            add_load_button = QPushButton('-')
+            add_load_button.pressed.connect(self.remove_load)
+        else:
+            add_load_button = QPushButton('+')
+            add_load_button.pressed.connect(self.add_load)
+
+        # FormLayout to add load section
+        add_load_form_layout = QFormLayout()
+        # Adding Pl and Ql to add load FormLayout
+        add_load_form_layout.addRow("P<sub>L</sub> (MW)", pl_input)
+        add_load_form_layout.addRow("Q<sub>L</sub> (Mvar)", ql_input)
+        add_load_form_layout.addRow("Y", load_ground)
+
+        remove_bus_button = QPushButton("Remove bus")
+        remove_bus_button.pressed.connect(self.remove_bus)
+
+        bus_layout.addStretch()
+        bus_layout.addWidget(bus_title)
+        bus_layout.addLayout(bus_data_form_layout)
+        bus_layout.addWidget(add_generation_label)
+        bus_layout.addWidget(add_generation_button)
+        bus_layout.addLayout(add_generation_form_layout)
+        bus_layout.addWidget(add_load_label)
+        bus_layout.addWidget(add_load_button)
+        bus_layout.addLayout(add_load_form_layout)
+        bus_layout.addWidget(remove_bus_button)
+        bus_layout.addStretch()
+
+        self.clear_layout(self.left_sidebar_layout)
+        self.left_sidebar_layout.addLayout(bus_layout)
 
     def update_layout(self):
         """Hide or show specific layouts, based on the current element or
         passed parameters by trigger methods.
-        Called two times ever because self.doAfterMouseRelease is triggered
+        Called two times ever because self.update_values is triggered
         whenever the mouse is released
         ------------------------------------------------------------------------------------------------------
-        Called by: doAfterMouseRelease
+        Called by: update_values
         ------------------------------------------------------------------------------------------------------
         """
 
@@ -944,52 +923,14 @@ class MainWidget(QWidget):
         bus = self.bus_at(self._curr_element_coord)
         curve = self.curve_at(self._curr_element_coord)
         if bus is not None:
-            # Show bus inspect
-            self.hide_spacer()
-            self.clear_layout(self.new_line_type, True)
-            self.clear_layout(self.line_or_trafo_layout, True)
-            self.clear_layout(self.control_panel_layout, True)
-            self.clear_layout(self.bus_layout, False)
             self.bus_menu(bus)
         elif curve is not None:
             if isinstance(curve.obj, TransmissionLine):
-                # Show line inspect
-                self.hide_spacer()
-                self.clear_layout(self.new_line_type, True)
-                self.clear_layout(self.bus_layout, True)
-                self.clear_layout(self.line_or_trafo_layout, False)
-                self.choose_line.setChecked(True)
-                self.clear_layout(self.chosen_trafo_form_layout, True)
-                self.clear_layout(self.chosen_line_form_layout, False)
-                self.trafo_submit_push_button.setHidden(True)
-                self.remove_trafo_push_button.setHidden(True)
-                self.clear_layout(self.control_panel_layout, True)
-                self.remove_tl_push_button.setHidden(False)
-                self.update_line_model_options()
                 self.line_menu()
             elif isinstance(curve.obj, Transformer):
-                # Show trafo inspect
-                self.clear_layout(self.new_line_type, True)
-                self.hide_spacer()
-                self.clear_layout(self.bus_layout, True)
-                self.clear_layout(self.line_or_trafo_layout, False)
-                self.choose_trafo.setChecked(True)
-                self.clear_layout(self.chosen_trafo_form_layout, False)
-                self.clear_layout(self.chosen_line_form_layout, True)
-                self.trafo_submit_push_button.setHidden(False)
-                self.remove_trafo_push_button.setHidden(False)
-                self.remove_tl_push_button.setHidden(True)
-                self.tl_submit_by_model_button.setHidden(True)
-                self.tl_submit_by_impedance_button.setHidden(True)
-                self.clear_layout(self.control_panel_layout, True)
                 self.trafo_menu()
         else:
-            # No element case
-            self.clear_layout(self.bus_layout, True)
-            self.clear_layout(self.line_or_trafo_layout, True)
-            self.clear_layout(self.new_line_type, True)
-            self.clear_layout(self.control_panel_layout, True)
-            self.show_spacer()
+            self.no_menu()
 
     def add_line(self, curve):
         self.curves.append(curve)
@@ -1001,11 +942,12 @@ class MainWidget(QWidget):
 
     def add_bus(self):
         """
-        Called by: Scene.mouseDoubleClickEvent
+        Called by: editor.mouseDoubleClickEvent
         """
         coord = self._curr_element_coord
+        is_bus = isinstance(self.editor.bus_grid[coord], Bus)
         curve = self.curve_at(self._curr_element_coord)
-        if not isinstance(self.editor.bus_grid[coord], Bus) and not curve:
+        if not is_bus and curve is None:
             bus = self.system.add_bus()
             self.editor.bus_grid[coord] = bus
             self.status_msg.emit_sig("Added bus")
@@ -1013,87 +955,11 @@ class MainWidget(QWidget):
             self.editor.removeItem(self.editor.drawings[coord])
             self.status_msg.emit_sig("There is an element in this position!")
 
-    def submit_line(self, mode):
+    def submit_trafo(self, snom, x0, x1, primary, secondary):
         """
-        Updates the line parameters based on Y and Z or parameters from LINE_TYPES,
-        or converts a trafo into a line and update its parameters following
-        Called by: tlSubmitByImpedancePushButton.pressed, tlSubmitByModelPushButton.pressed
-
-        Parameters
-        ----------
-        mode: either 'parameters' or 'impedance'
-        """
-        curve = self.curve_at(self._curr_element_coord)
-        if isinstance(curve.obj, TransmissionLine):
-            # The element already is a line
-            line = curve.obj
-            if mode == 'parameters':
-                param_values = self.find_line_model_from_text()
-                # Current selected element is a line
-                # Update using properties
-                # Z and Y are obtained from the updated properties
-                if param_values is not None:
-                    ell = float(self.ell_line_edit.text()) * 1e3
-                    vbase = float(self.vbase_line_edit.text()) * 1e3
-                    self.submit_line_by_model(line, param_values, ell, vbase)
-                    self.update_layout()
-                    self.status_msg.emit_sig("Updated line with parameters")
-                else:
-                    self.status_msg.emit_sig("You have to choose a valid model")
-            elif mode == 'impedance':
-                # Current selected element is a line
-                # Update using impedance and admittance
-                R = float(self.tl_r_line_edit.text()) / 100
-                X = float(self.tl_x_line_edit.text()) / 100
-                Y = float(self.tl_b_line_edit.text()) / 100
-                Z = R + 1j * X
-                Y = 1j * Y
-                ell = float(self.ell_line_edit.text()) * 1e3
-                vbase = float(self.vbase_line_edit.text()) * 1e3
-                self.submit_line_by_impedance(line, Z, Y, ell, vbase)
-                self.update_layout()
-                self.status_msg.emit_sig("Update line with impedance")
-        elif isinstance(curve.obj, Transformer):
-            # The element is a trafo and will be converted into a line
-            trafo = curve.obj
-            self.remove_trafo(curve)
-            new_line = TransmissionLine(orig=trafo.orig, dest=trafo.dest)
-            if mode == 'parameters':
-                param_values = self.find_line_model_from_text()
-                if param_values is not None:
-                    ell = float(self.ell_line_edit.text()) * 1e3
-                    vbase = float(self.vbase_line_edit.text()) * 1e3
-                    self.submit_line_by_model(new_line, param_values, ell, vbase)
-                    self.status_msg.emit_sig("Trafo -> line, updated with parameters")
-                else:
-                    self.status_msg.emit_sig("You have to choose a valid model")
-            elif mode == 'impedance':
-                R = float(self.tl_r_line_edit.text()) / 100
-                X = float(self.tl_x_line_edit.text()) / 100
-                Y = float(self.tl_b_line_edit.text()) / 100
-                Z = R + 1j * X
-                Y = 1j * Y
-                ell = float(self.ell_line_edit.text()) * 1e3
-                vbase = float(self.vbase_line_edit.text()) * 1e3
-                self.submit_line_by_impedance(new_line, Z, Y, ell, vbase)
-                self.status_msg.emit_sig("Trafo -> line, updated with impedance")
-            new_curve = LineSegment(obj=new_line,
-                                    dlines=curve.dlines,
-                                    coords=curve.coords)
-            for line_drawing in new_curve.dlines:
-                blue_pen = QPen()
-                blue_pen.setColor(Qt.blue)
-                blue_pen.setWidthF(2.5)
-                line_drawing.setPen(blue_pen)
-                self.editor.addItem(line_drawing)
-            self.add_line(new_curve)
-            self.update_layout()
-
-    def submit_trafo(self):
-        """
-        Updates a trafo with the given parameters if the current element is a trafo
-        or converts a line into a trafo with the inputted parameters
-        Called by: trafoSubmitPushButton.pressed
+        Updates a trafo with the given parameters if the current element is a
+        trafo or converts a line into a trafo with the inputted parameters
+        Called by: trafo_submit_push_button.pressed
         """
         curve = self.curve_at(self._curr_element_coord)
         if isinstance(curve.obj, TransmissionLine):
@@ -1103,11 +969,11 @@ class MainWidget(QWidget):
             new_trafo = Transformer(
                 orig=line.orig,
                 dest=line.dest,
-                snom=float(self.snom_trafo_line_edit.text()) * 1e6,
-                jx0=float(self.x_zero_seq_trafo_line_edit.text()) / 100,
-                jx1=float(self.x_pos_seq_trafo_line_edit.text()) / 100,
-                primary=SYMBOL_TO_PY[self.trafo_primary.currentText()],
-                secondary=SYMBOL_TO_PY[self.trafo_secondary.currentText()]
+                snom=snom,
+                jx0=x0,
+                jx1=x1,
+                primary=primary,
+                secondary=secondary
             )
             new_curve = LineSegment(obj=new_trafo,
                                     dlines=curve.dlines,
@@ -1124,11 +990,11 @@ class MainWidget(QWidget):
         elif isinstance(curve.obj, Transformer):
             # Update parameters of selected trafo
             trafo = curve.obj
-            trafo.snom = float(self.snom_trafo_line_edit.text()) * 1e6
-            trafo.jx0 = float(self.x_zero_seq_trafo_line_edit.text()) / 100
-            trafo.jx1 = float(self.x_pos_seq_trafo_line_edit.text()) / 100
-            trafo.primary = SYMBOL_TO_PY[self.trafo_primary.currentText()]
-            trafo.secondary = SYMBOL_TO_PY[self.trafo_secondary.currentText()]
+            trafo.snom = snom
+            trafo.jx0 = x0
+            trafo.jx1 = x1
+            trafo.primary = primary
+            trafo.secondary = secondary
             self.update_layout()
             self.status_msg.emit_sig("Updated trafo parameters")
 
@@ -1183,7 +1049,7 @@ class MainWidget(QWidget):
 
     def remove_bus(self):
         """
-        Called by: RemoveBus.pressed
+        Called by: remove_bus_button.pressed
         """
         coord = self._curr_element_coord
         bus = self.bus_at(coord)
@@ -1197,49 +1063,29 @@ class MainWidget(QWidget):
 
     def add_gen(self):
         """Adds generation to the bus, make some QLineEdits activated
-        Called by: AddGenerationButton.pressed (__init__)
+        Called by: add_generation_button.pressed
         """
         bus = self.bus_at(self._curr_element_coord)
-        self.bus_v_value.setEnabled(True)
-        self.xd_line_edit.setEnabled(True)
-        if bus.bus_id > 0:
-            self.pg_input.setEnabled(True)
-        self.gen_ground.setEnabled(True)
-        self.add_generation_button.setText('OK')
+        self.bus_menu(bus, edit_gen=True)
         self.status_msg.emit_sig("Input generation data...")
-        self.add_generation_button.disconnect()
-        self.add_generation_button.pressed.connect(self.submit_gen)
 
-    def submit_gen(self):
+    def submit_gen(self, bus_v, pg, gen_ground, xd):
         """Updates bus parameters with the user input in bus inspector
-        Called by: AddedGenerationButton.pressed (add_gen)
+        Called by: add_generation_button.pressed
         """
         coord = self._curr_element_coord
         if isinstance(self.editor.bus_grid[coord], Bus):
             bus = self.bus_at(coord)
-            bus.v = float(self.bus_v_value.text())
-            bus.pg = float(self.pg_input.text()) / 100
-            bus.gen_ground = self.gen_ground.isChecked()
-            if self.xd_line_edit.text() == '\u221E':
-                bus.xd = np.inf
-            else:
-                bus.xd = float(self.xd_line_edit.text()) / 100
-            self.bus_v_value.setEnabled(False)
-            self.pg_input.setEnabled(False)
-            self.xd_line_edit.setEnabled(False)
-            self.gen_ground.setEnabled(False)
-            self.add_generation_button.disconnect()
-            if bus.bus_id > 0:
-                self.add_generation_button.setText('-')
-                self.add_generation_button.pressed.connect(self.remove_gen)
-            else:
-                self.add_generation_button.setText('EDIT')
-                self.add_generation_button.pressed.connect(self.add_gen)
+            bus.v = bus_v
+            bus.pg = pg
+            bus.gen_ground = gen_ground
+            bus.xd = xd
             self.status_msg.emit_sig("Added generation")
+            self.bus_menu(bus)
 
     def remove_gen(self):
         """
-        Called by: AddGenerationButton.pressed (submit_gen)
+        Called by: add_generation_button.pressed
         """
         coord = self._curr_element_coord
         if isinstance(self.editor.bus_grid[coord], Bus):
@@ -1249,44 +1095,32 @@ class MainWidget(QWidget):
             bus.xd = np.inf
             bus.gen_ground = False
             self.bus_menu(bus)
-            self.add_generation_button.setText('+')
-            self.add_generation_button.disconnect()
-            self.add_generation_button.pressed.connect(self.add_gen)
             self.status_msg.emit_sig("Removed generation")
 
     def add_load(self):
         """
-        Called by: AddLoadButton.pressed (__init__)
+        Called by: add_load_button.pressed
         """
-        self.pl_input.setEnabled(True)
-        self.ql_input.setEnabled(True)
-        self.load_ground.setEnabled(True)
-        self.add_load_button.setText("OK")
+        bus = self.bus_at(self._curr_element_coord)
+        self.bus_menu(bus, edit_load=True)
         self.status_msg.emit_sig("Input load data...")
-        self.add_load_button.disconnect()
-        self.add_load_button.pressed.connect(self.submit_load)
 
-    def submit_load(self):
+    def submit_load(self, pl, ql, load_ground):
         """
-        Called by: AddLoadButton.pressed (add_load)
+        Called by: add_load_button.pressed
         """
         coord = self._curr_element_coord
         if isinstance(self.editor.bus_grid[coord], Bus):
             bus = self.bus_at(coord)
-            bus.pl = float(self.pl_input.text()) / 100
-            bus.ql = float(self.ql_input.text()) / 100
-            bus.load_ground = SYMBOL_TO_PY[self.load_ground.currentText()]
-            self.pl_input.setEnabled(False)
-            self.ql_input.setEnabled(False)
-            self.load_ground.setEnabled(False)
-            self.add_load_button.setText('-')
-            self.add_load_button.disconnect()
-            self.add_load_button.pressed.connect(self.remove_load)
+            bus.pl = pl
+            bus.ql = ql
+            bus.load_ground = load_ground
             self.status_msg.emit_sig("Added load")
+            self.bus_menu(bus)
 
     def remove_load(self):
         """
-        Called by: AddLoadButton.pressed (submit_load)
+        Called by: add_load_button.pressed
         """
         coord = self._curr_element_coord
         if isinstance(self.editor.bus_grid[coord], Bus):
@@ -1295,9 +1129,6 @@ class MainWidget(QWidget):
             bus.ql = 0
             bus.load_ground = EARTH
             self.bus_menu(bus)
-            self.add_load_button.setText('+')
-            self.add_load_button.disconnect()
-            self.add_load_button.pressed.connect(self.add_load)
             self.status_msg.emit_sig("Removed load")
 
     def update_values(self):
@@ -1330,15 +1161,16 @@ class MainWidget(QWidget):
 class Window(QMainWindow):
     def __init__(self):
         super(Window, self).__init__()
+        self.status_bar = self.statusBar()
         # Central widget
         self.main_widget = MainWidget()
-        self.main_widget.status_msg.signal.connect(self.display_status_msg)
+        self.main_widget.status_msg.signal.connect(self.status_bar.showMessage)
         self.setCentralWidget(self.main_widget)
 
         self.initUI()
 
     def initUI(self):
-        self.display_status_msg("Ready")
+        self.status_bar.showMessage("Ready")
         # Actions
         new_sys = QAction("Start new system", self)
         new_sys.setShortcut("Ctrl+N")
@@ -1389,14 +1221,7 @@ class Window(QMainWindow):
         self.show()
 
     def configure_simulation(self):
-        self.main_widget.clear_layout(self.main_widget.bus_layout, True)
-        self.main_widget.clear_layout(self.main_widget.line_or_trafo_layout, True)
-        self.main_widget.clear_layout(self.main_widget.control_panel_layout, False)
-        self.main_widget.update_nmax_slider(self.main_widget.max_niter)
-        self.main_widget.update_nmax_label(self.main_widget.max_niter)
-
-    def display_status_msg(self, args):
-        self.statusBar().showMessage(args)
+        self.main_widget.control_panel_menu()
 
     def save_session(self):
         sessions_dir = getSessionsDir()
@@ -1446,13 +1271,11 @@ class Window(QMainWindow):
                           self.main_widget.editor.bus_grid, filename)
 
     def add_line_type(self):
-        self.main_widget.clear_layout(self.main_widget.new_line_type, False)
-        self.main_widget.clear_layout(self.main_widget.bus_layout, True)
-        self.main_widget.clear_layout(self.main_widget.line_or_trafo_layout, True)
-        self.display_status_msg("Adding new line model")
+        self.main_widget.new_line_model_menu()
+        self.status_bar.showMessage("Adding new line model")
 
     def edit_line_type(self):
-        self.display_status_msg("Editing line types is currently not implemented!")
+        self.status_bar.showMessage("Editing line types is currently not implemented!")
         raise NotImplementedError
 
     def start_new_session(self):
@@ -1508,20 +1331,20 @@ class Window(QMainWindow):
         for i in range(editor.size):
             for j in range(editor.size):
                 if isinstance(editor.bus_grid[i, j], Bus):
-                    point = (square_length / 2 + square_length * j,
-                             square_length / 2 + square_length * i)
+                    point = (square_length * (j + .5),
+                             square_length * (i + .5))
                     bus = editor.draw_bus(point)
                     editor.drawings[i, j] = bus
         for curve in self.main_widget.curves:
-            for pairs in interface_coordpairs(curve.coords, square_length):
+            for pair in interface_coordpairs(curve.coords, square_length):
                 if isinstance(curve.obj, TransmissionLine):
-                    dline = editor.draw_line(pairs, color='b')
+                    dline = editor.draw_line(pair[0], pair[1], color='b')
                 else:
-                    dline = editor.draw_line(pairs, color='r')
+                    dline = editor.draw_line(pair[0], pair[1], color='r')
                 curve.dlines.append(dline)
 
 
 def main():
     app = QApplication(sys.argv)
-    Window()
+    _ = Window()
     sys.exit(app.exec_())


### PR DESCRIPTION
This PR intends to improve code extensibility.
By creating the QWidget objects as local variables instead of instance attributes, there are no risks of overwriting function names; also, memory is continually relieved from keeping track of hidden widgets.
Finally, and most importantly, this makes it easy to create new sidebar menu options by simply adding/changing the corresponding member functions.

The following `MainWidget` functions are no longer required and could be safely removed:

- `hide_spacer`
- `show_spacer`
- `update_nmax_label`
- `update_nmax_slider`
- `find_line_model_from_text`
- `update_line_model_options`
- `submit_line`

The following `MainWidget` functions were introduced:
- `no_menu`
- `new_line_model_menu`
- `control_panel_menu`