### PR TITLE
Check for empty strings with `safe_float`

### DIFF
--- a/elegant/utils.py
+++ b/elegant/utils.py
@@ -55,3 +55,13 @@ def safe_repr(val, unit=1.0, fmt="{:.3g}"):
     if val == np.inf:
         return "\u221E"
     return fmt.format(val / unit)
+
+
+def safe_float(txt, unit=1.0):
+    if txt == "\u221E":
+        return np.inf
+    try:
+        val = float(txt) * unit
+    except ValueError:
+        val = np.nan
+    return val


### PR DESCRIPTION
This PR fixes #50 by introducing the function `safe_float`, which converts strings to float values while checking for infinities and catching `ValueError` exceptions (which are converted to `nan`). Also, in each submission method, a check for nans will not accept empty parameters as input, instead displaying a message on the status bar (as was already the case for `add_new_line_model`).